### PR TITLE
feat: add force code generation option for Blue artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           cache: 'npm'
 
       - run: npm ci --legacy-peer-deps
-      - uses: nrwl/nx-set-shas@v4
+      - uses: nrwl/nx-set-shas@v4.2.1
 
       # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
       # - run: npx nx-cloud record -- echo Hello World

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,8 @@ jobs:
           node-version: 20
           cache: 'npm'
 
-      - run: npm ci --legacy-peer-deps
+      - run: npm install
+
       - uses: nrwl/nx-set-shas@v4.2.1
 
       # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud

--- a/.github/workflows/process-blue-artifacts.yml
+++ b/.github/workflows/process-blue-artifacts.yml
@@ -9,6 +9,11 @@ on:
         description: 'Run ID of the blue-preprocessor workflow'
         required: true
         type: string
+      force_all_libraries:
+        description: 'Force code generation for all libraries (bypass filtering)'
+        required: false
+        type: boolean
+        default: false
 
 env:
   BASE_BRANCH: main
@@ -67,7 +72,12 @@ jobs:
         run: npm ci --legacy-peer-deps
 
       - name: Run script
-        run: npm run artifact-scaffolder
+        run: |
+          if [ "${{ inputs.force_all_libraries }}" = "true" ]; then
+            npm run artifact-scaffolder -- --force-all
+          else
+            npm run artifact-scaffolder
+          fi
 
       - name: Update dependencies and package-lock.json
         run: npm install

--- a/scripts/artifact-scaffolder/index.ts
+++ b/scripts/artifact-scaffolder/index.ts
@@ -24,6 +24,11 @@ async function main() {
   }
 
   const inputDir = args[0];
+  const forceAll = args.includes('--force-all');
+
+  if (forceAll) {
+    console.log('🚀 Force mode enabled: generating code for ALL libraries');
+  }
 
   if (!fs.existsSync(inputDir)) {
     console.error(`Input directory does not exist: ${inputDir}`);
@@ -68,14 +73,24 @@ async function main() {
     };
   });
 
-  const librariesNeedingCodeGeneration = libraryConfigs.filter(
-    (libraryConfig) => {
-      return (
-        !libraryConfig.exists ||
-        libraryConfig.currentBlueId !== libraryConfig.newBlueId
-      );
-    }
-  );
+  const librariesNeedingCodeGeneration = forceAll
+    ? libraryConfigs
+    : libraryConfigs.filter((libraryConfig) => {
+        return (
+          !libraryConfig.exists ||
+          libraryConfig.currentBlueId !== libraryConfig.newBlueId
+        );
+      });
+
+  if (librariesNeedingCodeGeneration.length === 0) {
+    console.log('No libraries needed code generation');
+  } else {
+    console.log(
+      `Processing ${librariesNeedingCodeGeneration.length} libraries${
+        forceAll ? ' (force mode)' : ''
+      }`
+    );
+  }
 
   for (const libraryConfig of librariesNeedingCodeGeneration) {
     if (!libraryConfig.exists) {
@@ -83,10 +98,6 @@ async function main() {
     }
 
     await syncCode(libraryConfig);
-  }
-
-  if (librariesNeedingCodeGeneration.length === 0) {
-    console.log('No libraries needed code generation');
   }
 
   await nxReset();

--- a/tools/nx-plugin/src/generators/zod-schemas/files/schema/__schemaName__.ts__tmpl__
+++ b/tools/nx-plugin/src/generators/zod-schemas/files/schema/__schemaName__.ts__tmpl__
@@ -1,20 +1,28 @@
 <% /* __schemaName__.ts__tmpl__ */ %>
 import { z } from 'zod';
-import { withTypeBlueId } from '@blue-company/language';
 import { blueIds } from '../blue-ids';
 <% if (importsByPath) { -%>
 <% Object.entries(importsByPath).forEach(([importPath, typeNames]) => { -%>
 <% const sortedNames = Array.from(typeNames).sort(); -%>
 <% if (sortedNames.length === 1) { -%>
-import { <%= sortedNames[0] %>Schema } from '<%= importPath %>';
+import { <%= sortedNames[0] %> } from '<%= importPath %>';
 <% } else { -%>
 import {
-  <%= sortedNames.map(n => n + 'Schema').join(',\n  ') %>,
+  <%= sortedNames.join(',\n  ') %>,
 } from '<%= importPath %>';
 <% } -%>
 <% }); -%>
 <% } -%>
 
+<% if (extendedType) { -%>
+export const <%= schemaName %>Schema = withTypeBlueId(blueIds.<%= schemaName %>)(
+  <%= extendedType.schemaName %>.extend({
+<% fields.forEach((fieldLine) => { -%>
+    <%- fieldLine %>,
+<% }) -%>
+  })
+);
+<% } else { -%>
 export const <%= schemaName %>Schema = withTypeBlueId(blueIds.<%= schemaName %>)(
   z.object({
 <% fields.forEach((fieldLine) => { -%>
@@ -22,5 +30,6 @@ export const <%= schemaName %>Schema = withTypeBlueId(blueIds.<%= schemaName %>)
 <% }) -%>
   })
 );
+<% } -%>
 
 export type <%= schemaName %> = z.infer<typeof <%= schemaName %>Schema>;

--- a/tools/nx-plugin/src/generators/zod-schemas/lib/generateZodType.ts
+++ b/tools/nx-plugin/src/generators/zod-schemas/lib/generateZodType.ts
@@ -5,7 +5,7 @@ import {
 } from './utils/blueTypes';
 import { getTypeNameFromBlueId } from './utils/getTypeNameFromBlueId';
 import { generateImportPath } from './generateImportPath';
-import { pascal } from '../../../utils/pascal';
+import { getSchemaName } from './utils/getSchemaName';
 
 /**
  * Generates a Zod type definition for a nested field reference.
@@ -45,11 +45,11 @@ function generateSubZodType(
     return 'z.unknown()';
   }
 
-  const schemaName = pascal(customTypeInfo.typeName);
+  const schemaName = getSchemaName(customTypeInfo.typeName);
   const importPath = generateImportPath(moduleIdentifier, customTypeInfo);
   schemaImportMap.set(schemaName, importPath);
 
-  return `${schemaName}Schema`;
+  return schemaName;
 }
 
 /**
@@ -103,10 +103,10 @@ export function generateZodType(
   } else {
     const customTypeInfo = getTypeNameFromBlueId(blueIds, typeId);
     if (customTypeInfo) {
-      const schemaName = pascal(customTypeInfo.typeName);
+      const schemaName = getSchemaName(customTypeInfo.typeName);
       const importPath = generateImportPath(moduleIdentifier, customTypeInfo);
       schemaImportMap.set(schemaName, importPath);
-      zodTypeDefinition = `${schemaName}Schema`;
+      zodTypeDefinition = schemaName;
     } else {
       zodTypeDefinition = 'z.unknown()';
     }

--- a/tools/nx-plugin/src/generators/zod-schemas/lib/processFields.ts
+++ b/tools/nx-plugin/src/generators/zod-schemas/lib/processFields.ts
@@ -77,6 +77,12 @@ function processTupleItems(
   return `z.tuple([${processedItems.join(', ')}])`;
 }
 
+const hasOnlySpecialFields = (objectToProcess: Record<string, unknown>) => {
+  return Object.keys(objectToProcess).every(
+    (key) => key === 'name' || key === 'description'
+  );
+};
+
 /**
  * Recursively processes an object structure to generate Zod schema field definitions.
  * Handles special fields (name, description), tuple fields, direct field definitions,
@@ -119,6 +125,16 @@ export function processFields(
         Object.keys(fieldObject).length === 1 &&
         'items' in fieldObject &&
         isNumericKeysObject(fieldObject.items);
+
+      if (hasOnlySpecialFields(fieldObject)) {
+        processedFields.push(
+          `${indentation}${formatFieldKey(
+            fieldKey
+          )}: blueNodeField().optional()`
+        );
+        schemaImportMap.set('blueNodeField', '@blue-company/language');
+        continue;
+      }
 
       if (isTupleField) {
         const tupleType = processTupleItems(

--- a/tools/nx-plugin/src/generators/zod-schemas/lib/utils/blueTypes.ts
+++ b/tools/nx-plugin/src/generators/zod-schemas/lib/utils/blueTypes.ts
@@ -9,6 +9,7 @@ export interface BlueField {
 export interface BlueType {
   name: string;
   description?: string;
+  type?: { blueId: string }; // For type inheritance/extension
   [key: string]: unknown; // allow arbitrary nested fields
 }
 

--- a/tools/nx-plugin/src/generators/zod-schemas/lib/utils/getSchemaName.ts
+++ b/tools/nx-plugin/src/generators/zod-schemas/lib/utils/getSchemaName.ts
@@ -1,0 +1,5 @@
+import { pascal } from '../../../../utils/pascal';
+
+export function getSchemaName(typeName: string) {
+  return `${pascal(typeName)}Schema`;
+}

--- a/tools/nx-plugin/src/generators/zod-schemas/zod-schemas.ts
+++ b/tools/nx-plugin/src/generators/zod-schemas/zod-schemas.ts
@@ -47,11 +47,8 @@ export async function zodSchemasGenerator(
       path.join(options.inputPath, blueTypeFile)
     );
 
-    const { schemaName, fields, importsByPath } = generateZodSchemaData(
-      blueTypeDefinition,
-      blueIds,
-      moduleIdentifier
-    );
+    const { schemaName, fields, importsByPath, extendedType } =
+      generateZodSchemaData(blueTypeDefinition, blueIds, moduleIdentifier);
 
     const templateDirectory = path.join(__dirname, './files/schema');
     generateFiles(tree, templateDirectory, schemasOutputDirectory, {
@@ -59,6 +56,7 @@ export async function zodSchemasGenerator(
       schemaName,
       fields,
       importsByPath,
+      extendedType,
     });
 
     generatedSchemaNames.push(schemaName);


### PR DESCRIPTION
- Introduced `force_all_libraries` input to the workflow to bypass filtering and generate code for all libraries.
- Updated the artifact scaffolder script to handle the new force mode, allowing for more flexible code generation.
- Enhanced Zod schema generation to support extended types and improved import handling.
- Refactored utility functions for better readability and maintainability.