### PR TITLE
fix: blueIds transformation and update schema generation

### DIFF
--- a/tools/nx-plugin/src/generators/blue-ids/blue-ids.ts
+++ b/tools/nx-plugin/src/generators/blue-ids/blue-ids.ts
@@ -9,7 +9,6 @@ import {
   updateJson,
 } from '@nx/devkit';
 import { BlueIdsGeneratorSchema } from './schema';
-import { pascal } from '../../utils/pascal';
 import { getTypeModuleInformations } from './utils/typeModule';
 
 /**
@@ -18,12 +17,7 @@ import { getTypeModuleInformations } from './utils/typeModule';
 function transformToModule(content: string): string {
   const data = yaml.load(content) as Record<string, unknown>;
 
-  // Transform the keys to camelCase
-  const transformedData = Object.fromEntries(
-    Object.entries(data).map(([key, value]) => [pascal(key), value])
-  );
-
-  const jsonString = JSON.stringify(transformedData, null, 2);
+  const jsonString = JSON.stringify(data, null, 2);
   return `export const blueIds = ${jsonString} as const;\n`;
 }
 

--- a/tools/nx-plugin/src/generators/zod-schemas/files/schema/__schemaName__.ts__tmpl__
+++ b/tools/nx-plugin/src/generators/zod-schemas/files/schema/__schemaName__.ts__tmpl__
@@ -15,7 +15,7 @@ import {
 <% } -%>
 
 <% if (extendedType) { -%>
-export const <%= schemaName %>Schema = withTypeBlueId(blueIds.<%= schemaName %>)(
+export const <%= schemaName %>Schema = withTypeBlueId(blueIds['<%= typeName %>'])(
   <%= extendedType.schemaName %>.extend({
 <% fields.forEach((fieldLine) => { -%>
     <%- fieldLine %>,
@@ -23,7 +23,7 @@ export const <%= schemaName %>Schema = withTypeBlueId(blueIds.<%= schemaName %>)
   })
 );
 <% } else { -%>
-export const <%= schemaName %>Schema = withTypeBlueId(blueIds.<%= schemaName %>)(
+export const <%= schemaName %>Schema = withTypeBlueId(blueIds['<%= typeName %>'])(
   z.object({
 <% fields.forEach((fieldLine) => { -%>
     <%- fieldLine %>,

--- a/tools/nx-plugin/src/generators/zod-schemas/lib/generateZodSchemaData.ts
+++ b/tools/nx-plugin/src/generators/zod-schemas/lib/generateZodSchemaData.ts
@@ -12,6 +12,8 @@ import { getSchemaName } from './utils/getSchemaName';
 export interface GeneratedSchemaData {
   /** The PascalCase name of the schema */
   schemaName: string;
+  /** The name of the type */
+  typeName: string;
   /** Array of field definitions for the z.object constructor */
   fields: string[];
   /** Map of import paths to sets of imported type names */
@@ -104,6 +106,7 @@ export function generateZodSchemaData(
   moduleIdentifier: string
 ): GeneratedSchemaData {
   const schemaName = pascal(typeDefinition.name);
+  const typeName = typeDefinition.name;
 
   // Default imports from @blue-company/language
   const schemaImportMap = new Map<string, string>([
@@ -130,6 +133,7 @@ export function generateZodSchemaData(
 
   return {
     schemaName,
+    typeName,
     fields,
     importsByPath,
     extendedType,

--- a/tools/nx-plugin/src/generators/zod-schemas/zod-schemas.ts
+++ b/tools/nx-plugin/src/generators/zod-schemas/zod-schemas.ts
@@ -47,13 +47,14 @@ export async function zodSchemasGenerator(
       path.join(options.inputPath, blueTypeFile)
     );
 
-    const { schemaName, fields, importsByPath, extendedType } =
+    const { schemaName, typeName, fields, importsByPath, extendedType } =
       generateZodSchemaData(blueTypeDefinition, blueIds, moduleIdentifier);
 
     const templateDirectory = path.join(__dirname, './files/schema');
     generateFiles(tree, templateDirectory, schemasOutputDirectory, {
       tmpl: '',
       schemaName,
+      typeName,
       fields,
       importsByPath,
       extendedType,


### PR DESCRIPTION
- Removed unnecessary transformation of keys to camelCase in the blueIds generator.
- Updated the zod schema generator to include typeName alongside schemaName for better clarity in generated files.
- Adjusted template files to use typeName for schema exports, ensuring consistency in naming conventions.