### PR TITLE
feat: update BlueRepository.blue + regenerate types (run 24520049014, trigger: repository_dispatch (blue-preprocessor-completed))

### DIFF
--- a/BlueRepository.blue
+++ b/BlueRepository.blue
@@ -5046,7 +5046,7 @@ packages:
             type:
               blueId: GZLRe2fEsvs1v7dVcg9kEnCrWEdM3cUZYhFH4XqN5jQT
         versions:
-          - repositoryVersionIndex: 0
+          - repositoryVersionIndex: 4
             typeBlueId: 2wqxtvdRHf7Z3qNNKnycnu3SBVqw4BenK8et9xeT7n86
             attributesAdded: []
       - status: dev
@@ -5250,7 +5250,7 @@ packages:
             blueId: Dh2LtUN8Umc478kif8VWsNM1FrL5usVEeevv2GKnKP4F
           description: Base PayNote where payer is merchant and payee is customer. Bank sets/validates payer channel bindings.
         versions:
-          - repositoryVersionIndex: 0
+          - repositoryVersionIndex: 4
             typeBlueId: 9dJ3W19EJ8MqtTJR8oidX8eRrkeB8xNQyqeTZeqBHZjo
             attributesAdded: []
       - status: stable
@@ -6354,7 +6354,7 @@ packages:
                       type:
                         blueId: DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K
         versions:
-          - repositoryVersionIndex: 0
+          - repositoryVersionIndex: 4
             typeBlueId: Dh2LtUN8Umc478kif8VWsNM1FrL5usVEeevv2GKnKP4F
             attributesAdded: []
       - status: dev
@@ -7052,7 +7052,7 @@ packages:
                             type:
                               blueId: DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K
         versions:
-          - repositoryVersionIndex: 0
+          - repositoryVersionIndex: 4
             typeBlueId: E22dx85oPtGX2DPRaKJzHVizREJmioNCJPurgBcHHhJ
             attributesAdded: []
       - status: dev
@@ -7319,3 +7319,5 @@ repositoryVersions:
   - vb22qGkPkict5EnAXzF9oyoEGBW6PYxucfAFeegBb6G
   - GzGCVkWasHpGFUWBvG71avwWvGWHeEdCPoMdKy47cTMe
   - J7UTMwNkrjuBVtnB1AmtgCwgkNdQuuBotNoQbxanAJBw
+  - 7x5HXkJCQPefxeQkAAC25hBM6x5XhDuoxNT618y9LWoV
+  - 9g7Gnfrq1c8koa8Fkngs8J9V7oKzMhuXQ7JGfpUfdQGp

--- a/libs/types/README.md
+++ b/libs/types/README.md
@@ -12,7 +12,7 @@ It contains:
 ## Repository Information
 
 - Repository name: **Blue Repository**
-- RepoBlueId: **J7UTMwNkrjuBVtnB1AmtgCwgkNdQuuBotNoQbxanAJBw**
+- RepoBlueId: **9g7Gnfrq1c8koa8Fkngs8J9V7oKzMhuXQ7JGfpUfdQGp**
 
 ## Installation
 

--- a/libs/types/package.json
+++ b/libs/types/package.json
@@ -100,6 +100,6 @@
   },
   "blueType": {
     "moduleName": "Blue Repository",
-    "moduleBlueId": "J7UTMwNkrjuBVtnB1AmtgCwgkNdQuuBotNoQbxanAJBw"
+    "moduleBlueId": "9g7Gnfrq1c8koa8Fkngs8J9V7oKzMhuXQ7JGfpUfdQGp"
   }
 }

--- a/libs/types/src/meta.ts
+++ b/libs/types/src/meta.ts
@@ -3,5 +3,7 @@ export const repositoryVersions = [
   'vb22qGkPkict5EnAXzF9oyoEGBW6PYxucfAFeegBb6G',
   'GzGCVkWasHpGFUWBvG71avwWvGWHeEdCPoMdKy47cTMe',
   'J7UTMwNkrjuBVtnB1AmtgCwgkNdQuuBotNoQbxanAJBw',
+  '7x5HXkJCQPefxeQkAAC25hBM6x5XhDuoxNT618y9LWoV',
+  '9g7Gnfrq1c8koa8Fkngs8J9V7oKzMhuXQ7JGfpUfdQGp',
 ] as const;
 export default { name, repositoryVersions } as const;

--- a/libs/types/src/packages/paynote/meta.ts
+++ b/libs/types/src/packages/paynote/meta.ts
@@ -162,7 +162,7 @@ const meta = {
       name: 'Card Transaction PayNote',
       versions: [
         {
-          repositoryVersionIndex: 0,
+          repositoryVersionIndex: 4,
           typeBlueId: '2wqxtvdRHf7Z3qNNKnycnu3SBVqw4BenK8et9xeT7n86',
           attributesAdded: [],
         },
@@ -294,7 +294,7 @@ const meta = {
       name: 'Merchant To Customer PayNote',
       versions: [
         {
-          repositoryVersionIndex: 0,
+          repositoryVersionIndex: 4,
           typeBlueId: '9dJ3W19EJ8MqtTJR8oidX8eRrkeB8xNQyqeTZeqBHZjo',
           attributesAdded: [],
         },
@@ -393,7 +393,7 @@ const meta = {
       name: 'PayNote',
       versions: [
         {
-          repositoryVersionIndex: 0,
+          repositoryVersionIndex: 4,
           typeBlueId: 'Dh2LtUN8Umc478kif8VWsNM1FrL5usVEeevv2GKnKP4F',
           attributesAdded: [],
         },
@@ -470,7 +470,7 @@ const meta = {
       name: 'PayNote Delivery',
       versions: [
         {
-          repositoryVersionIndex: 0,
+          repositoryVersionIndex: 4,
           typeBlueId: 'E22dx85oPtGX2DPRaKJzHVizREJmioNCJPurgBcHHhJ',
           attributesAdded: [],
         },


### PR DESCRIPTION
This PR contains an updated repository definition (BlueRepository.blue) and regenerated @blue-repository/types sources.

## Configuration
- Trigger: repository_dispatch (blue-preprocessor-completed)
- Run ID: 24520049014
- Source workflow: blue-preprocessor.yml
- Artifact: blue-repository-definition

## Changes
- Updated BlueRepository.blue
- Regenerated libs/types/src (contents, schemas, blue-ids, package exports)

Generated by the process-blue-artifacts workflow.