### PR TITLE
feat: update BlueRepository.blue + regenerate types (run 24565175690, trigger: repository_dispatch (blue-preprocessor-completed))

### DIFF
--- a/BlueRepository.blue
+++ b/BlueRepository.blue
@@ -5054,14 +5054,14 @@ packages:
         content:
           name: Card Transaction PayNote
           type:
-            blueId: 4kfReXTiPbwiptkS6DdriPwQubRnbiDm9ghWM9zkrQon
+            blueId: DJ6q5W2JcVYR8NpZ6CTZoMNZ9P8TaiLXkwWwyeTjg2Uu
           description: PayNote tied to a specific card transaction via ISO scheme identifiers.
           cardTransactionDetails:
             type:
               blueId: GZLRe2fEsvs1v7dVcg9kEnCrWEdM3cUZYhFH4XqN5jQT
         versions:
-          - repositoryVersionIndex: 5
-            typeBlueId: 6DEqU222KQbg7YGb1EjF7ySj7x42oLCamLGf65V2gaZk
+          - repositoryVersionIndex: 6
+            typeBlueId: Ja5fvEx8oyx8GSLUdAhtB4gi4qUGtnJYGJsGxQ86q3z
             attributesAdded: []
       - status: dev
         content:
@@ -5357,11 +5357,11 @@ packages:
         content:
           name: Merchant To Customer PayNote
           type:
-            blueId: 4kfReXTiPbwiptkS6DdriPwQubRnbiDm9ghWM9zkrQon
+            blueId: DJ6q5W2JcVYR8NpZ6CTZoMNZ9P8TaiLXkwWwyeTjg2Uu
           description: Base PayNote where payer is merchant and payee is customer. Bank sets/validates payer channel bindings.
         versions:
-          - repositoryVersionIndex: 5
-            typeBlueId: 7MnGGMg6HX7UAB1bGhTL7QfNAWKFeHH8SpnEkWgaWQtV
+          - repositoryVersionIndex: 6
+            typeBlueId: GRyCc29p1fQLpKARkjKNwTqt5zffv37rBsaE7RTjABtb
             attributesAdded: []
       - status: dev
         content:
@@ -6751,6 +6751,30 @@ packages:
                   blueId: DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K
               steps:
                 items:
+                  - name: Resolve PayNote Runtime Defaults
+                    type:
+                      blueId: ExZxT61PSpWHpEAtP2WKMXXqxEYN7Z13j7Zv36Dp99kS
+                    code:
+                      value: |
+                        const fallback = (current, value) =>
+                          current === null || current === undefined ? value : current;
+
+                        return {
+                          status: fallback(document('/status'), 'Pending'),
+                          amountFinalResolved: fallback(document('/amount/finalResolved'), 0),
+                          amountSecured: fallback(document('/amount/secured'), 0),
+                          amountCompleted: fallback(document('/amount/completed'), 0),
+                          amountReversed: fallback(document('/amount/reversed'), 0),
+                          completionLocked: fallback(document('/controls/completionLocked'), false),
+                          reversalLocked: fallback(document('/controls/reversalLocked'), false),
+                          transactionDetailsUpdateLocked: fallback(
+                            document('/controls/transactionDetailsUpdateLocked'),
+                            false
+                          ),
+                          transactionDetails: fallback(document('/transactionDetails'), {}),
+                        };
+                      type:
+                        blueId: DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K
                   - name: Initialize PayNote Runtime State
                     type:
                       blueId: FtHZJzH4hqAoGxFBjsmy1svfT4BwEBB4aHpFSZycZLLa
@@ -6765,7 +6789,7 @@ packages:
                             type:
                               blueId: DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K
                           val:
-                            value: Pending
+                            value: ${steps['Resolve PayNote Runtime Defaults'].status}
                             type:
                               blueId: DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K
                         - op:
@@ -6777,9 +6801,9 @@ packages:
                             type:
                               blueId: DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K
                           val:
-                            value: 0
+                            value: ${steps['Resolve PayNote Runtime Defaults'].amountFinalResolved}
                             type:
-                              blueId: 5WNMiV9Knz63B4dVY5JtMyh3FB4FSGqv7ceScvuapdE1
+                              blueId: DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K
                         - op:
                             value: replace
                             type:
@@ -6789,9 +6813,9 @@ packages:
                             type:
                               blueId: DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K
                           val:
-                            value: 0
+                            value: ${steps['Resolve PayNote Runtime Defaults'].amountSecured}
                             type:
-                              blueId: 5WNMiV9Knz63B4dVY5JtMyh3FB4FSGqv7ceScvuapdE1
+                              blueId: DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K
                         - op:
                             value: replace
                             type:
@@ -6801,9 +6825,9 @@ packages:
                             type:
                               blueId: DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K
                           val:
-                            value: 0
+                            value: ${steps['Resolve PayNote Runtime Defaults'].amountCompleted}
                             type:
-                              blueId: 5WNMiV9Knz63B4dVY5JtMyh3FB4FSGqv7ceScvuapdE1
+                              blueId: DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K
                         - op:
                             value: replace
                             type:
@@ -6813,9 +6837,9 @@ packages:
                             type:
                               blueId: DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K
                           val:
-                            value: 0
+                            value: ${steps['Resolve PayNote Runtime Defaults'].amountReversed}
                             type:
-                              blueId: 5WNMiV9Knz63B4dVY5JtMyh3FB4FSGqv7ceScvuapdE1
+                              blueId: DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K
                         - op:
                             value: replace
                             type:
@@ -6825,9 +6849,9 @@ packages:
                             type:
                               blueId: DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K
                           val:
-                            value: false
+                            value: ${steps['Resolve PayNote Runtime Defaults'].completionLocked}
                             type:
-                              blueId: 4EzhSubEimSQD3zrYHRtobfPPWntUuhEz8YcdxHsi12u
+                              blueId: DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K
                         - op:
                             value: replace
                             type:
@@ -6837,9 +6861,9 @@ packages:
                             type:
                               blueId: DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K
                           val:
-                            value: false
+                            value: ${steps['Resolve PayNote Runtime Defaults'].reversalLocked}
                             type:
-                              blueId: 4EzhSubEimSQD3zrYHRtobfPPWntUuhEz8YcdxHsi12u
+                              blueId: DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K
                         - op:
                             value: replace
                             type:
@@ -6849,9 +6873,9 @@ packages:
                             type:
                               blueId: DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K
                           val:
-                            value: false
+                            value: ${steps['Resolve PayNote Runtime Defaults'].transactionDetailsUpdateLocked}
                             type:
-                              blueId: 4EzhSubEimSQD3zrYHRtobfPPWntUuhEz8YcdxHsi12u
+                              blueId: DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K
                         - op:
                             value: replace
                             type:
@@ -6860,7 +6884,10 @@ packages:
                             value: /transactionDetails
                             type:
                               blueId: DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K
-                          val: {}
+                          val:
+                            value: ${steps['Resolve PayNote Runtime Defaults'].transactionDetails}
+                            type:
+                              blueId: DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K
             acceptPayNote:
               type:
                 blueId: BoAiqVUZv9Fum3wFqaX2JnQMBHJLxJSo2V9U2UBmCfsC
@@ -8324,8 +8351,8 @@ packages:
                         type:
                           blueId: DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K
         versions:
-          - repositoryVersionIndex: 5
-            typeBlueId: 4kfReXTiPbwiptkS6DdriPwQubRnbiDm9ghWM9zkrQon
+          - repositoryVersionIndex: 6
+            typeBlueId: DJ6q5W2JcVYR8NpZ6CTZoMNZ9P8TaiLXkwWwyeTjg2Uu
             attributesAdded: []
       - status: dev
         content:
@@ -8440,7 +8467,7 @@ packages:
               blueId: 4derXUpwPZDDkBpYPCTMr6t3mbeGU7AUYmvfW22cZior
             document:
               type:
-                blueId: 4kfReXTiPbwiptkS6DdriPwQubRnbiDm9ghWM9zkrQon
+                blueId: DJ6q5W2JcVYR8NpZ6CTZoMNZ9P8TaiLXkwWwyeTjg2Uu
             description: PayNote bootstrap request details.
           paymentMandateBootstrapRequest:
             type:
@@ -9043,8 +9070,8 @@ packages:
                             type:
                               blueId: DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K
         versions:
-          - repositoryVersionIndex: 5
-            typeBlueId: EziPPW12NGQo8Brd9C2FpM46BSSn2RhRX6PJbzKonFCE
+          - repositoryVersionIndex: 6
+            typeBlueId: DuqP4xc5kdpFREraHi3HEwX4f4jZt8mpzARbWjELnJn8
             attributesAdded: []
       - status: dev
         content:
@@ -9499,3 +9526,4 @@ repositoryVersions:
   - 7x5HXkJCQPefxeQkAAC25hBM6x5XhDuoxNT618y9LWoV
   - 9g7Gnfrq1c8koa8Fkngs8J9V7oKzMhuXQ7JGfpUfdQGp
   - 2iUtnWCNhsh5arVZxx7Xum4D8PM2NWBAbJ4XoaEfr4Kc
+  - 9RQUZnXwdjk6YqSamBbaX5ZpDPBcHJeFsPF2rM7zncyu

--- a/libs/types/README.md
+++ b/libs/types/README.md
@@ -12,7 +12,7 @@ It contains:
 ## Repository Information
 
 - Repository name: **Blue Repository**
-- RepoBlueId: **2iUtnWCNhsh5arVZxx7Xum4D8PM2NWBAbJ4XoaEfr4Kc**
+- RepoBlueId: **9RQUZnXwdjk6YqSamBbaX5ZpDPBcHJeFsPF2rM7zncyu**
 
 ## Installation
 

--- a/libs/types/package.json
+++ b/libs/types/package.json
@@ -100,6 +100,6 @@
   },
   "blueType": {
     "moduleName": "Blue Repository",
-    "moduleBlueId": "2iUtnWCNhsh5arVZxx7Xum4D8PM2NWBAbJ4XoaEfr4Kc"
+    "moduleBlueId": "9RQUZnXwdjk6YqSamBbaX5ZpDPBcHJeFsPF2rM7zncyu"
   }
 }

--- a/libs/types/src/meta.ts
+++ b/libs/types/src/meta.ts
@@ -6,5 +6,6 @@ export const repositoryVersions = [
   '7x5HXkJCQPefxeQkAAC25hBM6x5XhDuoxNT618y9LWoV',
   '9g7Gnfrq1c8koa8Fkngs8J9V7oKzMhuXQ7JGfpUfdQGp',
   '2iUtnWCNhsh5arVZxx7Xum4D8PM2NWBAbJ4XoaEfr4Kc',
+  '9RQUZnXwdjk6YqSamBbaX5ZpDPBcHJeFsPF2rM7zncyu',
 ] as const;
 export default { name, repositoryVersions } as const;

--- a/libs/types/src/packages/paynote/blue-ids.ts
+++ b/libs/types/src/packages/paynote/blue-ids.ts
@@ -28,7 +28,7 @@ export const blueIds = {
   'PayNote/Card Transaction Monitoring Stopped':
     'BYdTyyLphWQNKo1GBcnE1jQuaPyXexNnfzkXhMiRqmUr',
   'PayNote/Card Transaction PayNote':
-    '6DEqU222KQbg7YGb1EjF7ySj7x42oLCamLGf65V2gaZk',
+    'Ja5fvEx8oyx8GSLUdAhtB4gi4qUGtnJYGJsGxQ86q3z',
   'PayNote/Card Transaction Report':
     '2ibvMNB7oxcpkYpxpag2HLC81sRs3PUBFtqjbqN7ET8X',
   'PayNote/Child PayNote Issuance Declined':
@@ -63,7 +63,7 @@ export const blueIds = {
   'PayNote/Linked PayNote Started':
     '6vnMMWuq6qJ1hxLqL1P2ckCqC9JtJF3QNW8s7rMTgZ4Q',
   'PayNote/Merchant To Customer PayNote':
-    '7MnGGMg6HX7UAB1bGhTL7QfNAWKFeHH8SpnEkWgaWQtV',
+    'GRyCc29p1fQLpKARkjKNwTqt5zffv37rBsaE7RTjABtb',
   'PayNote/Payee Assignment Confirmed':
     '34v52X6nVj6muiD11W8nohLFn7DjT2RiaRYwjRNpq4v3',
   'PayNote/Payee Assignment Rejected':
@@ -120,7 +120,7 @@ export const blueIds = {
     'HPLY55rtyD7BVZaHWhB9iUP7AoFTykn6ZCF3K3BaBbVu',
   'PayNote/Payment Reversed After Completion':
     '81whmkSDanPULQUi4sMuVkxiWDLHb3VPC5PeLfJCXCGo',
-  'PayNote/PayNote': '4kfReXTiPbwiptkS6DdriPwQubRnbiDm9ghWM9zkrQon',
+  'PayNote/PayNote': 'DJ6q5W2JcVYR8NpZ6CTZoMNZ9P8TaiLXkwWwyeTjg2Uu',
   'PayNote/PayNote Acceptance Requested':
     '3kyFUyupzb49ZoxVHnUhVe4XAbEN1Hpy8zN9Dx75GNyc',
   'PayNote/PayNote Accepted': 'CfSpcRXYk2qwu1vNs9LL8rycBsxzL2R4LGyDdrDzwCjh',
@@ -134,7 +134,7 @@ export const blueIds = {
   'PayNote/PayNote Cancelled': '96buyUXwhkak8xKoCR5nAW9tMuwzkevJFdELVvwKxR6Y',
   'PayNote/PayNote Client Decision Discarded':
     'Da7ZSyWgvMyTfwDVhAgCkGf3H8dwHhouHsHgNzg3DZ2j',
-  'PayNote/PayNote Delivery': 'EziPPW12NGQo8Brd9C2FpM46BSSn2RhRX6PJbzKonFCE',
+  'PayNote/PayNote Delivery': 'DuqP4xc5kdpFREraHi3HEwX4f4jZt8mpzARbWjELnJn8',
   'PayNote/PayNote Delivery Failed':
     'GtFG4Nt2fAamUZi9fSZNotab3BEUuv236LuPAcErVj5y',
   'PayNote/PayNote Rejected': 'AdKfkwRfzRUxUKSzhRfYANsaUBNnz4u6JFWR66qhzyZe',

--- a/libs/types/src/packages/paynote/contents/CardTransactionPayNote.ts
+++ b/libs/types/src/packages/paynote/contents/CardTransactionPayNote.ts
@@ -8,6 +8,6 @@ export const CardTransactionPayNote = {
     'PayNote tied to a specific card transaction via ISO scheme identifiers.',
   name: 'Card Transaction PayNote',
   type: {
-    blueId: '4kfReXTiPbwiptkS6DdriPwQubRnbiDm9ghWM9zkrQon',
+    blueId: 'DJ6q5W2JcVYR8NpZ6CTZoMNZ9P8TaiLXkwWwyeTjg2Uu',
   },
 } as const;

--- a/libs/types/src/packages/paynote/contents/MerchantToCustomerPayNote.ts
+++ b/libs/types/src/packages/paynote/contents/MerchantToCustomerPayNote.ts
@@ -3,6 +3,6 @@ export const MerchantToCustomerPayNote = {
     'Base PayNote where payer is merchant and payee is customer. Bank sets/validates payer channel bindings.',
   name: 'Merchant To Customer PayNote',
   type: {
-    blueId: '4kfReXTiPbwiptkS6DdriPwQubRnbiDm9ghWM9zkrQon',
+    blueId: 'DJ6q5W2JcVYR8NpZ6CTZoMNZ9P8TaiLXkwWwyeTjg2Uu',
   },
 } as const;

--- a/libs/types/src/packages/paynote/contents/PayNote.ts
+++ b/libs/types/src/packages/paynote/contents/PayNote.ts
@@ -1256,6 +1256,19 @@ export const PayNote = {
       steps: {
         items: [
           {
+            code: {
+              type: {
+                blueId: 'DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K',
+              },
+              value:
+                "const fallback = (current, value) =>\n  current === null || current === undefined ? value : current;\n\nreturn {\n  status: fallback(document('/status'), 'Pending'),\n  amountFinalResolved: fallback(document('/amount/finalResolved'), 0),\n  amountSecured: fallback(document('/amount/secured'), 0),\n  amountCompleted: fallback(document('/amount/completed'), 0),\n  amountReversed: fallback(document('/amount/reversed'), 0),\n  completionLocked: fallback(document('/controls/completionLocked'), false),\n  reversalLocked: fallback(document('/controls/reversalLocked'), false),\n  transactionDetailsUpdateLocked: fallback(\n    document('/controls/transactionDetailsUpdateLocked'),\n    false\n  ),\n  transactionDetails: fallback(document('/transactionDetails'), {}),\n};\n",
+            },
+            name: 'Resolve PayNote Runtime Defaults',
+            type: {
+              blueId: 'ExZxT61PSpWHpEAtP2WKMXXqxEYN7Z13j7Zv36Dp99kS',
+            },
+          },
+          {
             changeset: {
               items: [
                 {
@@ -1275,7 +1288,8 @@ export const PayNote = {
                     type: {
                       blueId: 'DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K',
                     },
-                    value: 'Pending',
+                    value:
+                      "${steps['Resolve PayNote Runtime Defaults'].status}",
                   },
                 },
                 {
@@ -1293,9 +1307,10 @@ export const PayNote = {
                   },
                   val: {
                     type: {
-                      blueId: '5WNMiV9Knz63B4dVY5JtMyh3FB4FSGqv7ceScvuapdE1',
+                      blueId: 'DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K',
                     },
-                    value: 0,
+                    value:
+                      "${steps['Resolve PayNote Runtime Defaults'].amountFinalResolved}",
                   },
                 },
                 {
@@ -1313,9 +1328,10 @@ export const PayNote = {
                   },
                   val: {
                     type: {
-                      blueId: '5WNMiV9Knz63B4dVY5JtMyh3FB4FSGqv7ceScvuapdE1',
+                      blueId: 'DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K',
                     },
-                    value: 0,
+                    value:
+                      "${steps['Resolve PayNote Runtime Defaults'].amountSecured}",
                   },
                 },
                 {
@@ -1333,9 +1349,10 @@ export const PayNote = {
                   },
                   val: {
                     type: {
-                      blueId: '5WNMiV9Knz63B4dVY5JtMyh3FB4FSGqv7ceScvuapdE1',
+                      blueId: 'DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K',
                     },
-                    value: 0,
+                    value:
+                      "${steps['Resolve PayNote Runtime Defaults'].amountCompleted}",
                   },
                 },
                 {
@@ -1353,9 +1370,10 @@ export const PayNote = {
                   },
                   val: {
                     type: {
-                      blueId: '5WNMiV9Knz63B4dVY5JtMyh3FB4FSGqv7ceScvuapdE1',
+                      blueId: 'DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K',
                     },
-                    value: 0,
+                    value:
+                      "${steps['Resolve PayNote Runtime Defaults'].amountReversed}",
                   },
                 },
                 {
@@ -1373,9 +1391,10 @@ export const PayNote = {
                   },
                   val: {
                     type: {
-                      blueId: '4EzhSubEimSQD3zrYHRtobfPPWntUuhEz8YcdxHsi12u',
+                      blueId: 'DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K',
                     },
-                    value: false,
+                    value:
+                      "${steps['Resolve PayNote Runtime Defaults'].completionLocked}",
                   },
                 },
                 {
@@ -1393,9 +1412,10 @@ export const PayNote = {
                   },
                   val: {
                     type: {
-                      blueId: '4EzhSubEimSQD3zrYHRtobfPPWntUuhEz8YcdxHsi12u',
+                      blueId: 'DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K',
                     },
-                    value: false,
+                    value:
+                      "${steps['Resolve PayNote Runtime Defaults'].reversalLocked}",
                   },
                 },
                 {
@@ -1413,9 +1433,10 @@ export const PayNote = {
                   },
                   val: {
                     type: {
-                      blueId: '4EzhSubEimSQD3zrYHRtobfPPWntUuhEz8YcdxHsi12u',
+                      blueId: 'DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K',
                     },
-                    value: false,
+                    value:
+                      "${steps['Resolve PayNote Runtime Defaults'].transactionDetailsUpdateLocked}",
                   },
                 },
                 {
@@ -1431,7 +1452,13 @@ export const PayNote = {
                     },
                     value: '/transactionDetails',
                   },
-                  val: {},
+                  val: {
+                    type: {
+                      blueId: 'DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K',
+                    },
+                    value:
+                      "${steps['Resolve PayNote Runtime Defaults'].transactionDetails}",
+                  },
                 },
               ],
             },

--- a/libs/types/src/packages/paynote/contents/PayNoteDelivery.ts
+++ b/libs/types/src/packages/paynote/contents/PayNoteDelivery.ts
@@ -684,7 +684,7 @@ export const PayNoteDelivery = {
     description: 'PayNote bootstrap request details.',
     document: {
       type: {
-        blueId: '4kfReXTiPbwiptkS6DdriPwQubRnbiDm9ghWM9zkrQon',
+        blueId: 'DJ6q5W2JcVYR8NpZ6CTZoMNZ9P8TaiLXkwWwyeTjg2Uu',
       },
     },
     type: {

--- a/libs/types/src/packages/paynote/contents/index.ts
+++ b/libs/types/src/packages/paynote/contents/index.ts
@@ -14,7 +14,6 @@ import { FinalAmountResolutionRequested } from './FinalAmountResolutionRequested
 import { ReserveFundsAndCaptureImmediatelyRequested } from './ReserveFundsAndCaptureImmediatelyRequested';
 import { ReserveFundsRequested } from './ReserveFundsRequested';
 import { PaymentMandateAttached } from './PaymentMandateAttached';
-import { PayNote } from './PayNote';
 import { CancelBeforeCompletionRequested } from './CancelBeforeCompletionRequested';
 import { SettlementAmountSpecified } from './SettlementAmountSpecified';
 import { PaymentCancellationDeclined } from './PaymentCancellationDeclined';
@@ -26,7 +25,6 @@ import { StartCardTransactionMonitoringRequested } from './StartCardTransactionM
 import { ReservationReleaseDeclined } from './ReservationReleaseDeclined';
 import { FundsSecuringFailed } from './FundsSecuringFailed';
 import { PaymentMandateSpendSettled } from './PaymentMandateSpendSettled';
-import { CardTransactionPayNote } from './CardTransactionPayNote';
 import { TransactionIdentified } from './TransactionIdentified';
 import { PaymentMandateSpendAuthorizationResponded } from './PaymentMandateSpendAuthorizationResponded';
 import { LinkedPayNoteStarted } from './LinkedPayNoteStarted';
@@ -34,7 +32,6 @@ import { PayNoteAcceptedByClient } from './PayNoteAcceptedByClient';
 import { CompletePaymentRequested } from './CompletePaymentRequested';
 import { PaymentCompleted } from './PaymentCompleted';
 import { PaymentMandateSpendAuthorizationRequested } from './PaymentMandateSpendAuthorizationRequested';
-import { MerchantToCustomerPayNote } from './MerchantToCustomerPayNote';
 import { FinalAmountResolved } from './FinalAmountResolved';
 import { PaymentReversedAfterCompletion } from './PaymentReversedAfterCompletion';
 import { LinkedPayNoteStartFailed } from './LinkedPayNoteStartFailed';
@@ -71,7 +68,9 @@ import { ChildPayNoteIssuanceDeclined } from './ChildPayNoteIssuanceDeclined';
 import { PaymentCompletionLockChangeFailed } from './PaymentCompletionLockChangeFailed';
 import { CardTransactionCaptureLockRequested } from './CardTransactionCaptureLockRequested';
 import { CardTransactionCaptureUnlocked } from './CardTransactionCaptureUnlocked';
+import { PayNote } from './PayNote';
 import { PayNoteCancellationRequested } from './PayNoteCancellationRequested';
+import { PayNoteDelivery } from './PayNoteDelivery';
 import { CaptureFundsRequested } from './CaptureFundsRequested';
 import { FundsSecured } from './FundsSecured';
 import { PaymentReversalLockChangeFailed } from './PaymentReversalLockChangeFailed';
@@ -81,7 +80,6 @@ import { TransactionDetailsUpdateLocked } from './TransactionDetailsUpdateLocked
 import { TransactionDetailsUpdated } from './TransactionDetailsUpdated';
 import { PaymentCancellationFailed } from './PaymentCancellationFailed';
 import { CardTransactionCaptureLocked } from './CardTransactionCaptureLocked';
-import { PayNoteDelivery } from './PayNoteDelivery';
 import { ReverseCardChargeAndCaptureImmediatelyRequested } from './ReverseCardChargeAndCaptureImmediatelyRequested';
 import { ChildPayNoteIssued } from './ChildPayNoteIssued';
 import { ReverseCardChargeRequested } from './ReverseCardChargeRequested';
@@ -93,6 +91,7 @@ import { TransactionStatus } from './TransactionStatus';
 import { CaptureDeclined } from './CaptureDeclined';
 import { PayNoteCancellationRejected } from './PayNoteCancellationRejected';
 import { CardTransactionMonitoringStarted } from './CardTransactionMonitoringStarted';
+import { MerchantToCustomerPayNote } from './MerchantToCustomerPayNote';
 import { PayNoteDeliveryFailed } from './PayNoteDeliveryFailed';
 import { PaymentMandateAttachmentFailed } from './PaymentMandateAttachmentFailed';
 import { ReservationReleaseRequested } from './ReservationReleaseRequested';
@@ -101,6 +100,7 @@ import { CardTransactionDetails } from './CardTransactionDetails';
 import { PaymentReversalUnlocked } from './PaymentReversalUnlocked';
 import { PayNoteApproved } from './PayNoteApproved';
 import { CardChargeCompleted } from './CardChargeCompleted';
+import { CardTransactionPayNote } from './CardTransactionPayNote';
 import { TransactionDetailsUpdateRejected } from './TransactionDetailsUpdateRejected';
 
 export { TransactionInitiated } from './TransactionInitiated';
@@ -119,7 +119,6 @@ export { FinalAmountResolutionRequested } from './FinalAmountResolutionRequested
 export { ReserveFundsAndCaptureImmediatelyRequested } from './ReserveFundsAndCaptureImmediatelyRequested';
 export { ReserveFundsRequested } from './ReserveFundsRequested';
 export { PaymentMandateAttached } from './PaymentMandateAttached';
-export { PayNote } from './PayNote';
 export { CancelBeforeCompletionRequested } from './CancelBeforeCompletionRequested';
 export { SettlementAmountSpecified } from './SettlementAmountSpecified';
 export { PaymentCancellationDeclined } from './PaymentCancellationDeclined';
@@ -131,7 +130,6 @@ export { StartCardTransactionMonitoringRequested } from './StartCardTransactionM
 export { ReservationReleaseDeclined } from './ReservationReleaseDeclined';
 export { FundsSecuringFailed } from './FundsSecuringFailed';
 export { PaymentMandateSpendSettled } from './PaymentMandateSpendSettled';
-export { CardTransactionPayNote } from './CardTransactionPayNote';
 export { TransactionIdentified } from './TransactionIdentified';
 export { PaymentMandateSpendAuthorizationResponded } from './PaymentMandateSpendAuthorizationResponded';
 export { LinkedPayNoteStarted } from './LinkedPayNoteStarted';
@@ -139,7 +137,6 @@ export { PayNoteAcceptedByClient } from './PayNoteAcceptedByClient';
 export { CompletePaymentRequested } from './CompletePaymentRequested';
 export { PaymentCompleted } from './PaymentCompleted';
 export { PaymentMandateSpendAuthorizationRequested } from './PaymentMandateSpendAuthorizationRequested';
-export { MerchantToCustomerPayNote } from './MerchantToCustomerPayNote';
 export { FinalAmountResolved } from './FinalAmountResolved';
 export { PaymentReversedAfterCompletion } from './PaymentReversedAfterCompletion';
 export { LinkedPayNoteStartFailed } from './LinkedPayNoteStartFailed';
@@ -176,7 +173,9 @@ export { ChildPayNoteIssuanceDeclined } from './ChildPayNoteIssuanceDeclined';
 export { PaymentCompletionLockChangeFailed } from './PaymentCompletionLockChangeFailed';
 export { CardTransactionCaptureLockRequested } from './CardTransactionCaptureLockRequested';
 export { CardTransactionCaptureUnlocked } from './CardTransactionCaptureUnlocked';
+export { PayNote } from './PayNote';
 export { PayNoteCancellationRequested } from './PayNoteCancellationRequested';
+export { PayNoteDelivery } from './PayNoteDelivery';
 export { CaptureFundsRequested } from './CaptureFundsRequested';
 export { FundsSecured } from './FundsSecured';
 export { PaymentReversalLockChangeFailed } from './PaymentReversalLockChangeFailed';
@@ -186,7 +185,6 @@ export { TransactionDetailsUpdateLocked } from './TransactionDetailsUpdateLocked
 export { TransactionDetailsUpdated } from './TransactionDetailsUpdated';
 export { PaymentCancellationFailed } from './PaymentCancellationFailed';
 export { CardTransactionCaptureLocked } from './CardTransactionCaptureLocked';
-export { PayNoteDelivery } from './PayNoteDelivery';
 export { ReverseCardChargeAndCaptureImmediatelyRequested } from './ReverseCardChargeAndCaptureImmediatelyRequested';
 export { ChildPayNoteIssued } from './ChildPayNoteIssued';
 export { ReverseCardChargeRequested } from './ReverseCardChargeRequested';
@@ -198,6 +196,7 @@ export { TransactionStatus } from './TransactionStatus';
 export { CaptureDeclined } from './CaptureDeclined';
 export { PayNoteCancellationRejected } from './PayNoteCancellationRejected';
 export { CardTransactionMonitoringStarted } from './CardTransactionMonitoringStarted';
+export { MerchantToCustomerPayNote } from './MerchantToCustomerPayNote';
 export { PayNoteDeliveryFailed } from './PayNoteDeliveryFailed';
 export { PaymentMandateAttachmentFailed } from './PaymentMandateAttachmentFailed';
 export { ReservationReleaseRequested } from './ReservationReleaseRequested';
@@ -206,6 +205,7 @@ export { CardTransactionDetails } from './CardTransactionDetails';
 export { PaymentReversalUnlocked } from './PaymentReversalUnlocked';
 export { PayNoteApproved } from './PayNoteApproved';
 export { CardChargeCompleted } from './CardChargeCompleted';
+export { CardTransactionPayNote } from './CardTransactionPayNote';
 export { TransactionDetailsUpdateRejected } from './TransactionDetailsUpdateRejected';
 
 export const contents = {
@@ -233,7 +233,6 @@ export const contents = {
     ReserveFundsAndCaptureImmediatelyRequested,
   '3Y3TYmSfZMmPYKmF5i3eR8YcVPNP5Sic2bZN8xRnvMWm': ReserveFundsRequested,
   '49TYrHpnk2gepJiGduJP3afrnT2DJ6kDxqF4Y9M4C4t7': PaymentMandateAttached,
-  '4kfReXTiPbwiptkS6DdriPwQubRnbiDm9ghWM9zkrQon': PayNote,
   '4oyKGB49m8MuAFdxgHZauwhDFvdBgziHnb9CCGeKNqEc':
     CancelBeforeCompletionRequested,
   '4pVAdZo93FHRRkAkshqCZW4pUvvV1ccczJZ2Lu4jkD1D': SettlementAmountSpecified,
@@ -248,7 +247,6 @@ export const contents = {
   '653sCbbRH3RiKhGjmVxh6wFVs4rn54wJRKDXRMKBZtjA': ReservationReleaseDeclined,
   '67BprL1WeSSpJDKawcnaNC6VF2vz68JQ5qrVfi37biBA': FundsSecuringFailed,
   '6aPqmL9AQV31CCV576ZmEcUgysbdbQAfAig9J5VYeR6v': PaymentMandateSpendSettled,
-  '6DEqU222KQbg7YGb1EjF7ySj7x42oLCamLGf65V2gaZk': CardTransactionPayNote,
   '6gQWKeJHZEbBo13Vvyf2nsdg7TA9kLSYdzMaJgySPG7V': TransactionIdentified,
   '6UFd89oNox3PCpeVFaaCXwbGDp3k3Qc56e4DktnK3F8P':
     PaymentMandateSpendAuthorizationResponded,
@@ -258,7 +256,6 @@ export const contents = {
   '72eeCYvygiChLj529TP1HKKBaYyB5TBa15Y3cn3JGsak': PaymentCompleted,
   '7EKvVzbT63C2taKWfLf9J2BiVL7BCL6Ld86tH8b9kmxF':
     PaymentMandateSpendAuthorizationRequested,
-  '7MnGGMg6HX7UAB1bGhTL7QfNAWKFeHH8SpnEkWgaWQtV': MerchantToCustomerPayNote,
   '7oKW3Fozo1KUPgxo4PdF6jJJQ83z11mBbpZF2xCENGDX': FinalAmountResolved,
   '81whmkSDanPULQUi4sMuVkxiWDLHb3VPC5PeLfJCXCGo':
     PaymentReversedAfterCompletion,
@@ -307,7 +304,9 @@ export const contents = {
   DhxGBjA6Gow9E6ZKZ49SdziihHZ4PeXxFNatSqmesKZu:
     CardTransactionCaptureLockRequested,
   DiowRXdCBw83YCn5Pwcg2YABaVQZ1p4Wk1L9DJfajqp5: CardTransactionCaptureUnlocked,
+  DJ6q5W2JcVYR8NpZ6CTZoMNZ9P8TaiLXkwWwyeTjg2Uu: PayNote,
   DqiwzsNLbHCh6PaDF6wy6ZqBSF5JV5nAQSKFKTPRTbGB: PayNoteCancellationRequested,
+  DuqP4xc5kdpFREraHi3HEwX4f4jZt8mpzARbWjELnJn8: PayNoteDelivery,
   DvxKVEFsDmgA1hcBDfh7t42NgTRLaxXjCrB48DufP3i3: CaptureFundsRequested,
   DvxVaiLspGpmTY5SiZDb85sJLcvzBCoJCjCHSAmVFbGT: FundsSecured,
   DYUz7mcFpgQdRNwwsSSBdDe3CYtfRbAeAUiEv6tuLDhy: PaymentReversalLockChangeFailed,
@@ -317,7 +316,6 @@ export const contents = {
   EsyQj8xWb1Kf2ESjDq1UR6PK2hx4fpnyGiEWJ14ttC8a: TransactionDetailsUpdated,
   ExfGtqDcSr7RkvA7XzdV5B1MVc7CPacHpanjGBtGhjyk: PaymentCancellationFailed,
   EXoQHkYEDQdhGd3AeXBryzxmCTXsvTjXTfZmjwuqqbHt: CardTransactionCaptureLocked,
-  EziPPW12NGQo8Brd9C2FpM46BSSn2RhRX6PJbzKonFCE: PayNoteDelivery,
   F4gfZeY8P8dkfwNSbEfq7xQ8axiHdfqgzGQQr3HLDyzC:
     ReverseCardChargeAndCaptureImmediatelyRequested,
   FAZCx2s5eq9zPV64LdHNFYbjjxD3ci1ZqyTcQk5WhXAs: ChildPayNoteIssued,
@@ -331,6 +329,7 @@ export const contents = {
   GaYDPA7TTqWuoxioCYFPeyqomjH4g3YDtFxHv9yLRQ8A: PayNoteCancellationRejected,
   GcKHzzeu5qehMo1JLGN7X5tSzrHM2iJoscN2qmkB5RPm:
     CardTransactionMonitoringStarted,
+  GRyCc29p1fQLpKARkjKNwTqt5zffv37rBsaE7RTjABtb: MerchantToCustomerPayNote,
   GtFG4Nt2fAamUZi9fSZNotab3BEUuv236LuPAcErVj5y: PayNoteDeliveryFailed,
   GTwsVrbVb31sMub1vvU2KyY2nA8ekKWYDoqNAB1m4Vh2: PaymentMandateAttachmentFailed,
   GU8nkSnUuMs6632rHQyBndRtjDcMB9ZSbgwkGYcfGt97: ReservationReleaseRequested,
@@ -339,5 +338,6 @@ export const contents = {
   HPLY55rtyD7BVZaHWhB9iUP7AoFTykn6ZCF3K3BaBbVu: PaymentReversalUnlocked,
   HQTUxErobqhSuhWo9DAC1WwaG9oYdjfmdKprGtV4TeEK: PayNoteApproved,
   Hrz9kzWXTXDfK2XEkRJtHqdKzHaQq919NcRL8QMAvEEQ: CardChargeCompleted,
+  Ja5fvEx8oyx8GSLUdAhtB4gi4qUGtnJYGJsGxQ86q3z: CardTransactionPayNote,
   tF2fYwf8b7HwErSWAduxWXoV8v7pMQPHVCsSZhZzhmT: TransactionDetailsUpdateRejected,
 } as const;

--- a/libs/types/src/packages/paynote/meta.ts
+++ b/libs/types/src/packages/paynote/meta.ts
@@ -168,13 +168,13 @@ const meta = {
         },
       ],
     },
-    '6DEqU222KQbg7YGb1EjF7ySj7x42oLCamLGf65V2gaZk': {
+    Ja5fvEx8oyx8GSLUdAhtB4gi4qUGtnJYGJsGxQ86q3z: {
       status: 'dev',
       name: 'Card Transaction PayNote',
       versions: [
         {
-          repositoryVersionIndex: 5,
-          typeBlueId: '6DEqU222KQbg7YGb1EjF7ySj7x42oLCamLGf65V2gaZk',
+          repositoryVersionIndex: 6,
+          typeBlueId: 'Ja5fvEx8oyx8GSLUdAhtB4gi4qUGtnJYGJsGxQ86q3z',
           attributesAdded: [],
         },
       ],
@@ -377,13 +377,13 @@ const meta = {
         },
       ],
     },
-    '7MnGGMg6HX7UAB1bGhTL7QfNAWKFeHH8SpnEkWgaWQtV': {
+    GRyCc29p1fQLpKARkjKNwTqt5zffv37rBsaE7RTjABtb: {
       status: 'dev',
       name: 'Merchant To Customer PayNote',
       versions: [
         {
-          repositoryVersionIndex: 5,
-          typeBlueId: '7MnGGMg6HX7UAB1bGhTL7QfNAWKFeHH8SpnEkWgaWQtV',
+          repositoryVersionIndex: 6,
+          typeBlueId: 'GRyCc29p1fQLpKARkjKNwTqt5zffv37rBsaE7RTjABtb',
           attributesAdded: [],
         },
       ],
@@ -707,13 +707,13 @@ const meta = {
         },
       ],
     },
-    '4kfReXTiPbwiptkS6DdriPwQubRnbiDm9ghWM9zkrQon': {
+    DJ6q5W2JcVYR8NpZ6CTZoMNZ9P8TaiLXkwWwyeTjg2Uu: {
       status: 'dev',
       name: 'PayNote',
       versions: [
         {
-          repositoryVersionIndex: 5,
-          typeBlueId: '4kfReXTiPbwiptkS6DdriPwQubRnbiDm9ghWM9zkrQon',
+          repositoryVersionIndex: 6,
+          typeBlueId: 'DJ6q5W2JcVYR8NpZ6CTZoMNZ9P8TaiLXkwWwyeTjg2Uu',
           attributesAdded: [],
         },
       ],
@@ -806,13 +806,13 @@ const meta = {
         },
       ],
     },
-    EziPPW12NGQo8Brd9C2FpM46BSSn2RhRX6PJbzKonFCE: {
+    DuqP4xc5kdpFREraHi3HEwX4f4jZt8mpzARbWjELnJn8: {
       status: 'dev',
       name: 'PayNote Delivery',
       versions: [
         {
-          repositoryVersionIndex: 5,
-          typeBlueId: 'EziPPW12NGQo8Brd9C2FpM46BSSn2RhRX6PJbzKonFCE',
+          repositoryVersionIndex: 6,
+          typeBlueId: 'DuqP4xc5kdpFREraHi3HEwX4f4jZt8mpzARbWjELnJn8',
           attributesAdded: [],
         },
       ],

--- a/libs/types/src/packages/paynote/schemas/index.ts
+++ b/libs/types/src/packages/paynote/schemas/index.ts
@@ -233,7 +233,7 @@ export const schemas = {
     CardTransactionMonitoringStartedSchema,
   BYdTyyLphWQNKo1GBcnE1jQuaPyXexNnfzkXhMiRqmUr:
     CardTransactionMonitoringStoppedSchema,
-  '6DEqU222KQbg7YGb1EjF7ySj7x42oLCamLGf65V2gaZk': CardTransactionPayNoteSchema,
+  Ja5fvEx8oyx8GSLUdAhtB4gi4qUGtnJYGJsGxQ86q3z: CardTransactionPayNoteSchema,
   '2ibvMNB7oxcpkYpxpag2HLC81sRs3PUBFtqjbqN7ET8X': CardTransactionReportSchema,
   DFKVw43E36kimqj64FyiiVxE9yNuB22SETFx5M4WAi9m:
     ChildPayNoteIssuanceDeclinedSchema,
@@ -260,8 +260,7 @@ export const schemas = {
   BQioEtRPYv2fWVryRsSYQc1Vnp9eyX3CYDrNY1hEy1Ye:
     LinkedPayNoteStartRespondedSchema,
   '6vnMMWuq6qJ1hxLqL1P2ckCqC9JtJF3QNW8s7rMTgZ4Q': LinkedPayNoteStartedSchema,
-  '7MnGGMg6HX7UAB1bGhTL7QfNAWKFeHH8SpnEkWgaWQtV':
-    MerchantToCustomerPayNoteSchema,
+  GRyCc29p1fQLpKARkjKNwTqt5zffv37rBsaE7RTjABtb: MerchantToCustomerPayNoteSchema,
   '34v52X6nVj6muiD11W8nohLFn7DjT2RiaRYwjRNpq4v3':
     PayeeAssignmentConfirmedSchema,
   CNFxs2PfxjDh7HNCaehyxNJ8zAdLbmgTcH12rU8VA7yi: PayeeAssignmentRejectedSchema,
@@ -307,7 +306,7 @@ export const schemas = {
   HPLY55rtyD7BVZaHWhB9iUP7AoFTykn6ZCF3K3BaBbVu: PaymentReversalUnlockedSchema,
   '81whmkSDanPULQUi4sMuVkxiWDLHb3VPC5PeLfJCXCGo':
     PaymentReversedAfterCompletionSchema,
-  '4kfReXTiPbwiptkS6DdriPwQubRnbiDm9ghWM9zkrQon': PayNoteSchema,
+  DJ6q5W2JcVYR8NpZ6CTZoMNZ9P8TaiLXkwWwyeTjg2Uu: PayNoteSchema,
   '3kyFUyupzb49ZoxVHnUhVe4XAbEN1Hpy8zN9Dx75GNyc':
     PayNoteAcceptanceRequestedSchema,
   CfSpcRXYk2qwu1vNs9LL8rycBsxzL2R4LGyDdrDzwCjh: PayNoteAcceptedSchema,
@@ -320,7 +319,7 @@ export const schemas = {
   '96buyUXwhkak8xKoCR5nAW9tMuwzkevJFdELVvwKxR6Y': PayNoteCancelledSchema,
   Da7ZSyWgvMyTfwDVhAgCkGf3H8dwHhouHsHgNzg3DZ2j:
     PayNoteClientDecisionDiscardedSchema,
-  EziPPW12NGQo8Brd9C2FpM46BSSn2RhRX6PJbzKonFCE: PayNoteDeliverySchema,
+  DuqP4xc5kdpFREraHi3HEwX4f4jZt8mpzARbWjELnJn8: PayNoteDeliverySchema,
   GtFG4Nt2fAamUZi9fSZNotab3BEUuv236LuPAcErVj5y: PayNoteDeliveryFailedSchema,
   AdKfkwRfzRUxUKSzhRfYANsaUBNnz4u6JFWR66qhzyZe: PayNoteRejectedSchema,
   EGRRGwNnReqfQQhKnML28DWz9MvvC3B5JgbBrCUxrZ3G: PayNoteRejectedByClientSchema,


### PR DESCRIPTION
This PR contains an updated repository definition (BlueRepository.blue) and regenerated @blue-repository/types sources.

## Configuration
- Trigger: repository_dispatch (blue-preprocessor-completed)
- Run ID: 24565175690
- Source workflow: blue-preprocessor.yml
- Artifact: blue-repository-definition

## Changes
- Updated BlueRepository.blue
- Regenerated libs/types/src (contents, schemas, blue-ids, package exports)

Generated by the process-blue-artifacts workflow.