### PR TITLE
feat: update BlueRepository.blue + regenerate types (run 24720731763, trigger: repository_dispatch (blue-preprocessor-completed))

### DIFF
--- a/BlueRepository.blue
+++ b/BlueRepository.blue
@@ -5198,14 +5198,14 @@ packages:
         content:
           name: Card Transaction PayNote
           type:
-            blueId: DJ6q5W2JcVYR8NpZ6CTZoMNZ9P8TaiLXkwWwyeTjg2Uu
+            blueId: 7fWr1Bguxi4xnhXx4dpGjaLtjEBgUjyjjaV3vt492Z9
           description: PayNote tied to a specific card transaction via ISO scheme identifiers.
           cardTransactionDetails:
             type:
               blueId: GZLRe2fEsvs1v7dVcg9kEnCrWEdM3cUZYhFH4XqN5jQT
         versions:
-          - repositoryVersionIndex: 6
-            typeBlueId: Ja5fvEx8oyx8GSLUdAhtB4gi4qUGtnJYGJsGxQ86q3z
+          - repositoryVersionIndex: 8
+            typeBlueId: DuNTUpW45aVkLzXh5C63KiiAk5SGCWGTdE3M5iKRBab4
             attributesAdded: []
       - status: dev
         content:
@@ -5501,11 +5501,11 @@ packages:
         content:
           name: Merchant To Customer PayNote
           type:
-            blueId: DJ6q5W2JcVYR8NpZ6CTZoMNZ9P8TaiLXkwWwyeTjg2Uu
+            blueId: 7fWr1Bguxi4xnhXx4dpGjaLtjEBgUjyjjaV3vt492Z9
           description: Base PayNote where payer is merchant and payee is customer. Bank sets/validates payer channel bindings.
         versions:
-          - repositoryVersionIndex: 6
-            typeBlueId: GRyCc29p1fQLpKARkjKNwTqt5zffv37rBsaE7RTjABtb
+          - repositoryVersionIndex: 8
+            typeBlueId: 85z8zJij5hoyZSVXHbHKUcyrMPKUAXQ9QnFyVrtGegJ1
             attributesAdded: []
       - status: dev
         content:
@@ -6810,6 +6810,10 @@ packages:
           name: PayNote
           description: |
             A document attached to exactly one transaction that governs what should happen with that transaction.
+          kind:
+            value: PayNote
+            type:
+              blueId: DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K
           status:
             type:
               blueId: DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K
@@ -6871,6 +6875,14 @@ packages:
               description: |
                 Full explanation of the process, conditions, and special rules. Markdown recommended.
           contracts:
+            search:
+              type:
+                blueId: 5KdjguBmn7AwB9d8tjKxRh4xUHU9T8WDJ4dbaY6qgPvx
+              kv:
+                kind:
+                  value: /kind
+                  type:
+                    blueId: DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K
             payerChannel:
               type:
                 blueId: DcoJyCh7XXxy1nR5xjy7qfkUgQ1GiZnKKSxh8DJusBSr
@@ -8495,8 +8507,8 @@ packages:
                         type:
                           blueId: DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K
         versions:
-          - repositoryVersionIndex: 6
-            typeBlueId: DJ6q5W2JcVYR8NpZ6CTZoMNZ9P8TaiLXkwWwyeTjg2Uu
+          - repositoryVersionIndex: 8
+            typeBlueId: 7fWr1Bguxi4xnhXx4dpGjaLtjEBgUjyjjaV3vt492Z9
             attributesAdded: []
       - status: dev
         content:
@@ -8611,7 +8623,7 @@ packages:
               blueId: 4derXUpwPZDDkBpYPCTMr6t3mbeGU7AUYmvfW22cZior
             document:
               type:
-                blueId: DJ6q5W2JcVYR8NpZ6CTZoMNZ9P8TaiLXkwWwyeTjg2Uu
+                blueId: 7fWr1Bguxi4xnhXx4dpGjaLtjEBgUjyjjaV3vt492Z9
             description: PayNote bootstrap request details.
           paymentMandateBootstrapRequest:
             type:
@@ -9214,8 +9226,8 @@ packages:
                             type:
                               blueId: DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K
         versions:
-          - repositoryVersionIndex: 6
-            typeBlueId: DuqP4xc5kdpFREraHi3HEwX4f4jZt8mpzARbWjELnJn8
+          - repositoryVersionIndex: 8
+            typeBlueId: FPsSzcPnRKzYdvXvzqSZ44dBPsTuGkbHwF47CEHt8EjH
             attributesAdded: []
       - status: dev
         content:
@@ -9672,3 +9684,4 @@ repositoryVersions:
   - 2iUtnWCNhsh5arVZxx7Xum4D8PM2NWBAbJ4XoaEfr4Kc
   - 9RQUZnXwdjk6YqSamBbaX5ZpDPBcHJeFsPF2rM7zncyu
   - HJT4uiGF9qWmZSgdZ3oChgRXkKaFzmrZHqwuNPoRCDpG
+  - 96W8M1cHNU9Vo7UGbFmiCXqQrNovqEK1WuADFmd9Nnko

--- a/libs/types/README.md
+++ b/libs/types/README.md
@@ -12,7 +12,7 @@ It contains:
 ## Repository Information
 
 - Repository name: **Blue Repository**
-- RepoBlueId: **HJT4uiGF9qWmZSgdZ3oChgRXkKaFzmrZHqwuNPoRCDpG**
+- RepoBlueId: **96W8M1cHNU9Vo7UGbFmiCXqQrNovqEK1WuADFmd9Nnko**
 
 ## Installation
 

--- a/libs/types/package.json
+++ b/libs/types/package.json
@@ -100,6 +100,6 @@
   },
   "blueType": {
     "moduleName": "Blue Repository",
-    "moduleBlueId": "HJT4uiGF9qWmZSgdZ3oChgRXkKaFzmrZHqwuNPoRCDpG"
+    "moduleBlueId": "96W8M1cHNU9Vo7UGbFmiCXqQrNovqEK1WuADFmd9Nnko"
   }
 }

--- a/libs/types/src/meta.ts
+++ b/libs/types/src/meta.ts
@@ -8,5 +8,6 @@ export const repositoryVersions = [
   '2iUtnWCNhsh5arVZxx7Xum4D8PM2NWBAbJ4XoaEfr4Kc',
   '9RQUZnXwdjk6YqSamBbaX5ZpDPBcHJeFsPF2rM7zncyu',
   'HJT4uiGF9qWmZSgdZ3oChgRXkKaFzmrZHqwuNPoRCDpG',
+  '96W8M1cHNU9Vo7UGbFmiCXqQrNovqEK1WuADFmd9Nnko',
 ] as const;
 export default { name, repositoryVersions } as const;

--- a/libs/types/src/packages/paynote/blue-ids.ts
+++ b/libs/types/src/packages/paynote/blue-ids.ts
@@ -28,7 +28,7 @@ export const blueIds = {
   'PayNote/Card Transaction Monitoring Stopped':
     'BYdTyyLphWQNKo1GBcnE1jQuaPyXexNnfzkXhMiRqmUr',
   'PayNote/Card Transaction PayNote':
-    'Ja5fvEx8oyx8GSLUdAhtB4gi4qUGtnJYGJsGxQ86q3z',
+    'DuNTUpW45aVkLzXh5C63KiiAk5SGCWGTdE3M5iKRBab4',
   'PayNote/Card Transaction Report':
     '2ibvMNB7oxcpkYpxpag2HLC81sRs3PUBFtqjbqN7ET8X',
   'PayNote/Child PayNote Issuance Declined':
@@ -63,7 +63,7 @@ export const blueIds = {
   'PayNote/Linked PayNote Started':
     '6vnMMWuq6qJ1hxLqL1P2ckCqC9JtJF3QNW8s7rMTgZ4Q',
   'PayNote/Merchant To Customer PayNote':
-    'GRyCc29p1fQLpKARkjKNwTqt5zffv37rBsaE7RTjABtb',
+    '85z8zJij5hoyZSVXHbHKUcyrMPKUAXQ9QnFyVrtGegJ1',
   'PayNote/Payee Assignment Confirmed':
     '34v52X6nVj6muiD11W8nohLFn7DjT2RiaRYwjRNpq4v3',
   'PayNote/Payee Assignment Rejected':
@@ -120,7 +120,7 @@ export const blueIds = {
     'HPLY55rtyD7BVZaHWhB9iUP7AoFTykn6ZCF3K3BaBbVu',
   'PayNote/Payment Reversed After Completion':
     '81whmkSDanPULQUi4sMuVkxiWDLHb3VPC5PeLfJCXCGo',
-  'PayNote/PayNote': 'DJ6q5W2JcVYR8NpZ6CTZoMNZ9P8TaiLXkwWwyeTjg2Uu',
+  'PayNote/PayNote': '7fWr1Bguxi4xnhXx4dpGjaLtjEBgUjyjjaV3vt492Z9',
   'PayNote/PayNote Acceptance Requested':
     '3kyFUyupzb49ZoxVHnUhVe4XAbEN1Hpy8zN9Dx75GNyc',
   'PayNote/PayNote Accepted': 'CfSpcRXYk2qwu1vNs9LL8rycBsxzL2R4LGyDdrDzwCjh',
@@ -134,7 +134,7 @@ export const blueIds = {
   'PayNote/PayNote Cancelled': '96buyUXwhkak8xKoCR5nAW9tMuwzkevJFdELVvwKxR6Y',
   'PayNote/PayNote Client Decision Discarded':
     'Da7ZSyWgvMyTfwDVhAgCkGf3H8dwHhouHsHgNzg3DZ2j',
-  'PayNote/PayNote Delivery': 'DuqP4xc5kdpFREraHi3HEwX4f4jZt8mpzARbWjELnJn8',
+  'PayNote/PayNote Delivery': 'FPsSzcPnRKzYdvXvzqSZ44dBPsTuGkbHwF47CEHt8EjH',
   'PayNote/PayNote Delivery Failed':
     'GtFG4Nt2fAamUZi9fSZNotab3BEUuv236LuPAcErVj5y',
   'PayNote/PayNote Rejected': 'AdKfkwRfzRUxUKSzhRfYANsaUBNnz4u6JFWR66qhzyZe',

--- a/libs/types/src/packages/paynote/contents/CardTransactionPayNote.ts
+++ b/libs/types/src/packages/paynote/contents/CardTransactionPayNote.ts
@@ -8,6 +8,6 @@ export const CardTransactionPayNote = {
     'PayNote tied to a specific card transaction via ISO scheme identifiers.',
   name: 'Card Transaction PayNote',
   type: {
-    blueId: 'DJ6q5W2JcVYR8NpZ6CTZoMNZ9P8TaiLXkwWwyeTjg2Uu',
+    blueId: '7fWr1Bguxi4xnhXx4dpGjaLtjEBgUjyjjaV3vt492Z9',
   },
 } as const;

--- a/libs/types/src/packages/paynote/contents/MerchantToCustomerPayNote.ts
+++ b/libs/types/src/packages/paynote/contents/MerchantToCustomerPayNote.ts
@@ -3,6 +3,6 @@ export const MerchantToCustomerPayNote = {
     'Base PayNote where payer is merchant and payee is customer. Bank sets/validates payer channel bindings.',
   name: 'Merchant To Customer PayNote',
   type: {
-    blueId: 'DJ6q5W2JcVYR8NpZ6CTZoMNZ9P8TaiLXkwWwyeTjg2Uu',
+    blueId: '7fWr1Bguxi4xnhXx4dpGjaLtjEBgUjyjjaV3vt492Z9',
   },
 } as const;

--- a/libs/types/src/packages/paynote/contents/PayNote.ts
+++ b/libs/types/src/packages/paynote/contents/PayNote.ts
@@ -2294,6 +2294,19 @@ export const PayNote = {
         blueId: 'CGdxkNjPcsdescqLPz6SNLsMyak6demQQr7RoKNHbCyv',
       },
     },
+    search: {
+      kv: {
+        kind: {
+          type: {
+            blueId: 'DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K',
+          },
+          value: '/kind',
+        },
+      },
+      type: {
+        blueId: '5KdjguBmn7AwB9d8tjKxRh4xUHU9T8WDJ4dbaY6qgPvx',
+      },
+    },
     secureFunds: {
       channel: {
         type: {
@@ -2652,6 +2665,12 @@ export const PayNote = {
   },
   description:
     'A document attached to exactly one transaction that governs what should happen with that transaction.\n',
+  kind: {
+    type: {
+      blueId: 'DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K',
+    },
+    value: 'PayNote',
+  },
   name: 'PayNote',
   payNoteInitialStateDescription: {
     details: {

--- a/libs/types/src/packages/paynote/contents/PayNoteDelivery.ts
+++ b/libs/types/src/packages/paynote/contents/PayNoteDelivery.ts
@@ -684,7 +684,7 @@ export const PayNoteDelivery = {
     description: 'PayNote bootstrap request details.',
     document: {
       type: {
-        blueId: 'DJ6q5W2JcVYR8NpZ6CTZoMNZ9P8TaiLXkwWwyeTjg2Uu',
+        blueId: '7fWr1Bguxi4xnhXx4dpGjaLtjEBgUjyjjaV3vt492Z9',
       },
     },
     type: {

--- a/libs/types/src/packages/paynote/contents/index.ts
+++ b/libs/types/src/packages/paynote/contents/index.ts
@@ -32,8 +32,10 @@ import { PayNoteAcceptedByClient } from './PayNoteAcceptedByClient';
 import { CompletePaymentRequested } from './CompletePaymentRequested';
 import { PaymentCompleted } from './PaymentCompleted';
 import { PaymentMandateSpendAuthorizationRequested } from './PaymentMandateSpendAuthorizationRequested';
+import { PayNote } from './PayNote';
 import { FinalAmountResolved } from './FinalAmountResolved';
 import { PaymentReversedAfterCompletion } from './PaymentReversedAfterCompletion';
+import { MerchantToCustomerPayNote } from './MerchantToCustomerPayNote';
 import { LinkedPayNoteStartFailed } from './LinkedPayNoteStartFailed';
 import { TransactionDetailsUpdateUnlocked } from './TransactionDetailsUpdateUnlocked';
 import { FundsSecuringDeclined } from './FundsSecuringDeclined';
@@ -68,9 +70,8 @@ import { ChildPayNoteIssuanceDeclined } from './ChildPayNoteIssuanceDeclined';
 import { PaymentCompletionLockChangeFailed } from './PaymentCompletionLockChangeFailed';
 import { CardTransactionCaptureLockRequested } from './CardTransactionCaptureLockRequested';
 import { CardTransactionCaptureUnlocked } from './CardTransactionCaptureUnlocked';
-import { PayNote } from './PayNote';
 import { PayNoteCancellationRequested } from './PayNoteCancellationRequested';
-import { PayNoteDelivery } from './PayNoteDelivery';
+import { CardTransactionPayNote } from './CardTransactionPayNote';
 import { CaptureFundsRequested } from './CaptureFundsRequested';
 import { FundsSecured } from './FundsSecured';
 import { PaymentReversalLockChangeFailed } from './PaymentReversalLockChangeFailed';
@@ -85,13 +86,13 @@ import { ChildPayNoteIssued } from './ChildPayNoteIssued';
 import { ReverseCardChargeRequested } from './ReverseCardChargeRequested';
 import { PaymentReversalDeclined } from './PaymentReversalDeclined';
 import { PaymentReversalFailed } from './PaymentReversalFailed';
+import { PayNoteDelivery } from './PayNoteDelivery';
 import { TransactionInitiationFailed } from './TransactionInitiationFailed';
 import { CaptureFailed } from './CaptureFailed';
 import { TransactionStatus } from './TransactionStatus';
 import { CaptureDeclined } from './CaptureDeclined';
 import { PayNoteCancellationRejected } from './PayNoteCancellationRejected';
 import { CardTransactionMonitoringStarted } from './CardTransactionMonitoringStarted';
-import { MerchantToCustomerPayNote } from './MerchantToCustomerPayNote';
 import { PayNoteDeliveryFailed } from './PayNoteDeliveryFailed';
 import { PaymentMandateAttachmentFailed } from './PaymentMandateAttachmentFailed';
 import { ReservationReleaseRequested } from './ReservationReleaseRequested';
@@ -100,7 +101,6 @@ import { CardTransactionDetails } from './CardTransactionDetails';
 import { PaymentReversalUnlocked } from './PaymentReversalUnlocked';
 import { PayNoteApproved } from './PayNoteApproved';
 import { CardChargeCompleted } from './CardChargeCompleted';
-import { CardTransactionPayNote } from './CardTransactionPayNote';
 import { TransactionDetailsUpdateRejected } from './TransactionDetailsUpdateRejected';
 
 export { TransactionInitiated } from './TransactionInitiated';
@@ -137,8 +137,10 @@ export { PayNoteAcceptedByClient } from './PayNoteAcceptedByClient';
 export { CompletePaymentRequested } from './CompletePaymentRequested';
 export { PaymentCompleted } from './PaymentCompleted';
 export { PaymentMandateSpendAuthorizationRequested } from './PaymentMandateSpendAuthorizationRequested';
+export { PayNote } from './PayNote';
 export { FinalAmountResolved } from './FinalAmountResolved';
 export { PaymentReversedAfterCompletion } from './PaymentReversedAfterCompletion';
+export { MerchantToCustomerPayNote } from './MerchantToCustomerPayNote';
 export { LinkedPayNoteStartFailed } from './LinkedPayNoteStartFailed';
 export { TransactionDetailsUpdateUnlocked } from './TransactionDetailsUpdateUnlocked';
 export { FundsSecuringDeclined } from './FundsSecuringDeclined';
@@ -173,9 +175,8 @@ export { ChildPayNoteIssuanceDeclined } from './ChildPayNoteIssuanceDeclined';
 export { PaymentCompletionLockChangeFailed } from './PaymentCompletionLockChangeFailed';
 export { CardTransactionCaptureLockRequested } from './CardTransactionCaptureLockRequested';
 export { CardTransactionCaptureUnlocked } from './CardTransactionCaptureUnlocked';
-export { PayNote } from './PayNote';
 export { PayNoteCancellationRequested } from './PayNoteCancellationRequested';
-export { PayNoteDelivery } from './PayNoteDelivery';
+export { CardTransactionPayNote } from './CardTransactionPayNote';
 export { CaptureFundsRequested } from './CaptureFundsRequested';
 export { FundsSecured } from './FundsSecured';
 export { PaymentReversalLockChangeFailed } from './PaymentReversalLockChangeFailed';
@@ -190,13 +191,13 @@ export { ChildPayNoteIssued } from './ChildPayNoteIssued';
 export { ReverseCardChargeRequested } from './ReverseCardChargeRequested';
 export { PaymentReversalDeclined } from './PaymentReversalDeclined';
 export { PaymentReversalFailed } from './PaymentReversalFailed';
+export { PayNoteDelivery } from './PayNoteDelivery';
 export { TransactionInitiationFailed } from './TransactionInitiationFailed';
 export { CaptureFailed } from './CaptureFailed';
 export { TransactionStatus } from './TransactionStatus';
 export { CaptureDeclined } from './CaptureDeclined';
 export { PayNoteCancellationRejected } from './PayNoteCancellationRejected';
 export { CardTransactionMonitoringStarted } from './CardTransactionMonitoringStarted';
-export { MerchantToCustomerPayNote } from './MerchantToCustomerPayNote';
 export { PayNoteDeliveryFailed } from './PayNoteDeliveryFailed';
 export { PaymentMandateAttachmentFailed } from './PaymentMandateAttachmentFailed';
 export { ReservationReleaseRequested } from './ReservationReleaseRequested';
@@ -205,7 +206,6 @@ export { CardTransactionDetails } from './CardTransactionDetails';
 export { PaymentReversalUnlocked } from './PaymentReversalUnlocked';
 export { PayNoteApproved } from './PayNoteApproved';
 export { CardChargeCompleted } from './CardChargeCompleted';
-export { CardTransactionPayNote } from './CardTransactionPayNote';
 export { TransactionDetailsUpdateRejected } from './TransactionDetailsUpdateRejected';
 
 export const contents = {
@@ -256,9 +256,11 @@ export const contents = {
   '72eeCYvygiChLj529TP1HKKBaYyB5TBa15Y3cn3JGsak': PaymentCompleted,
   '7EKvVzbT63C2taKWfLf9J2BiVL7BCL6Ld86tH8b9kmxF':
     PaymentMandateSpendAuthorizationRequested,
+  '7fWr1Bguxi4xnhXx4dpGjaLtjEBgUjyjjaV3vt492Z9': PayNote,
   '7oKW3Fozo1KUPgxo4PdF6jJJQ83z11mBbpZF2xCENGDX': FinalAmountResolved,
   '81whmkSDanPULQUi4sMuVkxiWDLHb3VPC5PeLfJCXCGo':
     PaymentReversedAfterCompletion,
+  '85z8zJij5hoyZSVXHbHKUcyrMPKUAXQ9QnFyVrtGegJ1': MerchantToCustomerPayNote,
   '8dggwonfALwrTSRhg8g8ncXFXierke2mogtEZQXHab64': LinkedPayNoteStartFailed,
   '8H1L8VGE9vXzbGgrv5RNkpYXngf43futPHQvnJ4SJD2B':
     TransactionDetailsUpdateUnlocked,
@@ -304,9 +306,8 @@ export const contents = {
   DhxGBjA6Gow9E6ZKZ49SdziihHZ4PeXxFNatSqmesKZu:
     CardTransactionCaptureLockRequested,
   DiowRXdCBw83YCn5Pwcg2YABaVQZ1p4Wk1L9DJfajqp5: CardTransactionCaptureUnlocked,
-  DJ6q5W2JcVYR8NpZ6CTZoMNZ9P8TaiLXkwWwyeTjg2Uu: PayNote,
   DqiwzsNLbHCh6PaDF6wy6ZqBSF5JV5nAQSKFKTPRTbGB: PayNoteCancellationRequested,
-  DuqP4xc5kdpFREraHi3HEwX4f4jZt8mpzARbWjELnJn8: PayNoteDelivery,
+  DuNTUpW45aVkLzXh5C63KiiAk5SGCWGTdE3M5iKRBab4: CardTransactionPayNote,
   DvxKVEFsDmgA1hcBDfh7t42NgTRLaxXjCrB48DufP3i3: CaptureFundsRequested,
   DvxVaiLspGpmTY5SiZDb85sJLcvzBCoJCjCHSAmVFbGT: FundsSecured,
   DYUz7mcFpgQdRNwwsSSBdDe3CYtfRbAeAUiEv6tuLDhy: PaymentReversalLockChangeFailed,
@@ -322,6 +323,7 @@ export const contents = {
   Fg5CEPi8Dbr1vBwGjzf8PbQNfuWfPP7HcLFChYwpRJq5: ReverseCardChargeRequested,
   Fk96a7GFSo2c3w7xWzaqnYhXXhLAAxj9Dwao8Hg9sdX: PaymentReversalDeclined,
   FNZQJMETUdV57VFyWHGPdQVPSjWsvGj7u4n2oKYbgAaH: PaymentReversalFailed,
+  FPsSzcPnRKzYdvXvzqSZ44dBPsTuGkbHwF47CEHt8EjH: PayNoteDelivery,
   FSfMCJpFDcB9zNfrd4gDhaDXpFhaSNToGbAdxSkw55V7: TransactionInitiationFailed,
   FUh3TARSh4TjnWKAkM5ydjFWLWEmrFByKMBQzcgQfqRW: CaptureFailed,
   FutWoAEUEb3wkmEm4YP4JGFPtu3B3PQ3m71BmnRFFnsQ: TransactionStatus,
@@ -329,7 +331,6 @@ export const contents = {
   GaYDPA7TTqWuoxioCYFPeyqomjH4g3YDtFxHv9yLRQ8A: PayNoteCancellationRejected,
   GcKHzzeu5qehMo1JLGN7X5tSzrHM2iJoscN2qmkB5RPm:
     CardTransactionMonitoringStarted,
-  GRyCc29p1fQLpKARkjKNwTqt5zffv37rBsaE7RTjABtb: MerchantToCustomerPayNote,
   GtFG4Nt2fAamUZi9fSZNotab3BEUuv236LuPAcErVj5y: PayNoteDeliveryFailed,
   GTwsVrbVb31sMub1vvU2KyY2nA8ekKWYDoqNAB1m4Vh2: PaymentMandateAttachmentFailed,
   GU8nkSnUuMs6632rHQyBndRtjDcMB9ZSbgwkGYcfGt97: ReservationReleaseRequested,
@@ -338,6 +339,5 @@ export const contents = {
   HPLY55rtyD7BVZaHWhB9iUP7AoFTykn6ZCF3K3BaBbVu: PaymentReversalUnlocked,
   HQTUxErobqhSuhWo9DAC1WwaG9oYdjfmdKprGtV4TeEK: PayNoteApproved,
   Hrz9kzWXTXDfK2XEkRJtHqdKzHaQq919NcRL8QMAvEEQ: CardChargeCompleted,
-  Ja5fvEx8oyx8GSLUdAhtB4gi4qUGtnJYGJsGxQ86q3z: CardTransactionPayNote,
   tF2fYwf8b7HwErSWAduxWXoV8v7pMQPHVCsSZhZzhmT: TransactionDetailsUpdateRejected,
 } as const;

--- a/libs/types/src/packages/paynote/meta.ts
+++ b/libs/types/src/packages/paynote/meta.ts
@@ -168,13 +168,13 @@ const meta = {
         },
       ],
     },
-    Ja5fvEx8oyx8GSLUdAhtB4gi4qUGtnJYGJsGxQ86q3z: {
+    DuNTUpW45aVkLzXh5C63KiiAk5SGCWGTdE3M5iKRBab4: {
       status: 'dev',
       name: 'Card Transaction PayNote',
       versions: [
         {
-          repositoryVersionIndex: 6,
-          typeBlueId: 'Ja5fvEx8oyx8GSLUdAhtB4gi4qUGtnJYGJsGxQ86q3z',
+          repositoryVersionIndex: 8,
+          typeBlueId: 'DuNTUpW45aVkLzXh5C63KiiAk5SGCWGTdE3M5iKRBab4',
           attributesAdded: [],
         },
       ],
@@ -377,13 +377,13 @@ const meta = {
         },
       ],
     },
-    GRyCc29p1fQLpKARkjKNwTqt5zffv37rBsaE7RTjABtb: {
+    '85z8zJij5hoyZSVXHbHKUcyrMPKUAXQ9QnFyVrtGegJ1': {
       status: 'dev',
       name: 'Merchant To Customer PayNote',
       versions: [
         {
-          repositoryVersionIndex: 6,
-          typeBlueId: 'GRyCc29p1fQLpKARkjKNwTqt5zffv37rBsaE7RTjABtb',
+          repositoryVersionIndex: 8,
+          typeBlueId: '85z8zJij5hoyZSVXHbHKUcyrMPKUAXQ9QnFyVrtGegJ1',
           attributesAdded: [],
         },
       ],
@@ -707,13 +707,13 @@ const meta = {
         },
       ],
     },
-    DJ6q5W2JcVYR8NpZ6CTZoMNZ9P8TaiLXkwWwyeTjg2Uu: {
+    '7fWr1Bguxi4xnhXx4dpGjaLtjEBgUjyjjaV3vt492Z9': {
       status: 'dev',
       name: 'PayNote',
       versions: [
         {
-          repositoryVersionIndex: 6,
-          typeBlueId: 'DJ6q5W2JcVYR8NpZ6CTZoMNZ9P8TaiLXkwWwyeTjg2Uu',
+          repositoryVersionIndex: 8,
+          typeBlueId: '7fWr1Bguxi4xnhXx4dpGjaLtjEBgUjyjjaV3vt492Z9',
           attributesAdded: [],
         },
       ],
@@ -806,13 +806,13 @@ const meta = {
         },
       ],
     },
-    DuqP4xc5kdpFREraHi3HEwX4f4jZt8mpzARbWjELnJn8: {
+    FPsSzcPnRKzYdvXvzqSZ44dBPsTuGkbHwF47CEHt8EjH: {
       status: 'dev',
       name: 'PayNote Delivery',
       versions: [
         {
-          repositoryVersionIndex: 6,
-          typeBlueId: 'DuqP4xc5kdpFREraHi3HEwX4f4jZt8mpzARbWjELnJn8',
+          repositoryVersionIndex: 8,
+          typeBlueId: 'FPsSzcPnRKzYdvXvzqSZ44dBPsTuGkbHwF47CEHt8EjH',
           attributesAdded: [],
         },
       ],

--- a/libs/types/src/packages/paynote/schemas/PayNote.ts
+++ b/libs/types/src/packages/paynote/schemas/PayNote.ts
@@ -7,6 +7,7 @@ import { SequentialWorkflowSchema } from '../../conversation/schemas/SequentialW
 import { SequentialWorkflowOperationSchema } from '../../conversation/schemas/SequentialWorkflowOperation';
 import { ChannelSchema } from '../../core/schemas/Channel';
 import { LifecycleEventChannelSchema } from '../../core/schemas/LifecycleEventChannel';
+import { SearchContractSchema } from '../../myos/schemas/SearchContract';
 
 export const PayNoteSchema = withTypeBlueId(blueIds['PayNote/PayNote'])(
   z.object({
@@ -101,6 +102,7 @@ export const PayNoteSchema = withTypeBlueId(blueIds['PayNote/PayNote'])(
         reverseAfterCompletion: OperationSchema.optional(),
         reverseAfterCompletionImpl:
           SequentialWorkflowOperationSchema.optional(),
+        search: SearchContractSchema.optional(),
         secureFunds: OperationSchema.optional(),
         secureFundsImpl: SequentialWorkflowOperationSchema.optional(),
         unlockPaymentCompletion: OperationSchema.optional(),
@@ -122,6 +124,7 @@ export const PayNoteSchema = withTypeBlueId(blueIds['PayNote/PayNote'])(
       .optional(),
     currency: CurrencySchema.optional(),
     description: z.string().optional(),
+    kind: z.string().optional(),
     name: z.string().optional(),
     payNoteInitialStateDescription: z
       .object({

--- a/libs/types/src/packages/paynote/schemas/index.ts
+++ b/libs/types/src/packages/paynote/schemas/index.ts
@@ -233,7 +233,7 @@ export const schemas = {
     CardTransactionMonitoringStartedSchema,
   BYdTyyLphWQNKo1GBcnE1jQuaPyXexNnfzkXhMiRqmUr:
     CardTransactionMonitoringStoppedSchema,
-  Ja5fvEx8oyx8GSLUdAhtB4gi4qUGtnJYGJsGxQ86q3z: CardTransactionPayNoteSchema,
+  DuNTUpW45aVkLzXh5C63KiiAk5SGCWGTdE3M5iKRBab4: CardTransactionPayNoteSchema,
   '2ibvMNB7oxcpkYpxpag2HLC81sRs3PUBFtqjbqN7ET8X': CardTransactionReportSchema,
   DFKVw43E36kimqj64FyiiVxE9yNuB22SETFx5M4WAi9m:
     ChildPayNoteIssuanceDeclinedSchema,
@@ -260,7 +260,8 @@ export const schemas = {
   BQioEtRPYv2fWVryRsSYQc1Vnp9eyX3CYDrNY1hEy1Ye:
     LinkedPayNoteStartRespondedSchema,
   '6vnMMWuq6qJ1hxLqL1P2ckCqC9JtJF3QNW8s7rMTgZ4Q': LinkedPayNoteStartedSchema,
-  GRyCc29p1fQLpKARkjKNwTqt5zffv37rBsaE7RTjABtb: MerchantToCustomerPayNoteSchema,
+  '85z8zJij5hoyZSVXHbHKUcyrMPKUAXQ9QnFyVrtGegJ1':
+    MerchantToCustomerPayNoteSchema,
   '34v52X6nVj6muiD11W8nohLFn7DjT2RiaRYwjRNpq4v3':
     PayeeAssignmentConfirmedSchema,
   CNFxs2PfxjDh7HNCaehyxNJ8zAdLbmgTcH12rU8VA7yi: PayeeAssignmentRejectedSchema,
@@ -306,7 +307,7 @@ export const schemas = {
   HPLY55rtyD7BVZaHWhB9iUP7AoFTykn6ZCF3K3BaBbVu: PaymentReversalUnlockedSchema,
   '81whmkSDanPULQUi4sMuVkxiWDLHb3VPC5PeLfJCXCGo':
     PaymentReversedAfterCompletionSchema,
-  DJ6q5W2JcVYR8NpZ6CTZoMNZ9P8TaiLXkwWwyeTjg2Uu: PayNoteSchema,
+  '7fWr1Bguxi4xnhXx4dpGjaLtjEBgUjyjjaV3vt492Z9': PayNoteSchema,
   '3kyFUyupzb49ZoxVHnUhVe4XAbEN1Hpy8zN9Dx75GNyc':
     PayNoteAcceptanceRequestedSchema,
   CfSpcRXYk2qwu1vNs9LL8rycBsxzL2R4LGyDdrDzwCjh: PayNoteAcceptedSchema,
@@ -319,7 +320,7 @@ export const schemas = {
   '96buyUXwhkak8xKoCR5nAW9tMuwzkevJFdELVvwKxR6Y': PayNoteCancelledSchema,
   Da7ZSyWgvMyTfwDVhAgCkGf3H8dwHhouHsHgNzg3DZ2j:
     PayNoteClientDecisionDiscardedSchema,
-  DuqP4xc5kdpFREraHi3HEwX4f4jZt8mpzARbWjELnJn8: PayNoteDeliverySchema,
+  FPsSzcPnRKzYdvXvzqSZ44dBPsTuGkbHwF47CEHt8EjH: PayNoteDeliverySchema,
   GtFG4Nt2fAamUZi9fSZNotab3BEUuv236LuPAcErVj5y: PayNoteDeliveryFailedSchema,
   AdKfkwRfzRUxUKSzhRfYANsaUBNnz4u6JFWR66qhzyZe: PayNoteRejectedSchema,
   EGRRGwNnReqfQQhKnML28DWz9MvvC3B5JgbBrCUxrZ3G: PayNoteRejectedByClientSchema,


### PR DESCRIPTION
This PR contains an updated repository definition (BlueRepository.blue) and regenerated @blue-repository/types sources.

## Configuration
- Trigger: repository_dispatch (blue-preprocessor-completed)
- Run ID: 24720731763
- Source workflow: blue-preprocessor.yml
- Artifact: blue-repository-definition

## Changes
- Updated BlueRepository.blue
- Regenerated libs/types/src (contents, schemas, blue-ids, package exports)

Generated by the process-blue-artifacts workflow.