### PR TITLE
chore(@blue-repository/types): update Blue Language packages to 4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,8 @@
         "libs/*"
       ],
       "dependencies": {
-        "@blue-labs/language": "2.0.0-rc.20",
-        "@blue-labs/repository-contract": "2.0.0-rc.20",
+        "@blue-labs/language": "^4.0.0",
+        "@blue-labs/repository-contract": "^4.0.0",
         "@nx/devkit": "22.0.2",
         "@phenomnomnominal/tsquery": "6.1.3",
         "zod": "^3.23.8"
@@ -1847,13 +1847,13 @@
       "license": "MIT"
     },
     "node_modules/@blue-labs/language": {
-      "version": "2.0.0-rc.20",
-      "resolved": "https://registry.npmjs.org/@blue-labs/language/-/language-2.0.0-rc.20.tgz",
-      "integrity": "sha512-VhSYsWPJwreKv3SiL7oMzIyvHkAZVlkLd3HfkPRoGHACvklo1mJDaPub05VeQZrJw+trQlihfH5LMrP8r94d5g==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@blue-labs/language/-/language-4.0.0.tgz",
+      "integrity": "sha512-khzNYa0ABabu0Nz2ZsHuWt6gPDjGGnsIh9/WJheE24Ns11ek/irYiiQS+0Qazrsr5L+p0rxj/nnZFh7RTfo3Og==",
       "license": "MIT",
       "dependencies": {
-        "@blue-labs/repository-contract": "2.0.0-rc.20",
-        "@blue-labs/shared-utils": "2.0.0-rc.20",
+        "@blue-labs/repository-contract": "4.0.0",
+        "@blue-labs/shared-utils": "4.0.0",
         "@types/big.js": "^6.2.2",
         "@types/js-yaml": "^4.0.9",
         "base32.js": "^0.1.0",
@@ -1869,21 +1869,21 @@
       }
     },
     "node_modules/@blue-labs/repository-contract": {
-      "version": "2.0.0-rc.20",
-      "resolved": "https://registry.npmjs.org/@blue-labs/repository-contract/-/repository-contract-2.0.0-rc.20.tgz",
-      "integrity": "sha512-XjGa3223L1hoUB/pUW7E/tYnUdMtiYuDjq5WJoCJ4iSMlQhrFWjS+2tghJQ00Jh4xyOEhCzg86EHUjXFNUXZiA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@blue-labs/repository-contract/-/repository-contract-4.0.0.tgz",
+      "integrity": "sha512-2UuC0aXl+N2ExYqz3+rfFkfwR5NYPr55t7aCYoRLAqcfG5tdfU6MqH+kTSQrfjNwklYbiJsczy35ovbxZ2bQtw==",
       "license": "MIT",
       "dependencies": {
-        "@blue-labs/shared-utils": "2.0.0-rc.20"
+        "@blue-labs/shared-utils": "4.0.0"
       },
       "peerDependencies": {
         "zod": "^3.20.0"
       }
     },
     "node_modules/@blue-labs/shared-utils": {
-      "version": "2.0.0-rc.20",
-      "resolved": "https://registry.npmjs.org/@blue-labs/shared-utils/-/shared-utils-2.0.0-rc.20.tgz",
-      "integrity": "sha512-SwCHq4Bj5d1rkGqpEOAZB8zMpUs7YE6YK7K3kKykKqPkLP+fJV4AsGqv3qtC08TZ1UuyYqRPlR3Vgki4OKD47g==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@blue-labs/shared-utils/-/shared-utils-4.0.0.tgz",
+      "integrity": "sha512-WwfSljQQB3HOtVkWWmsoEsptKYdCplsrSc6dDPTfGxBJZW3byGdxZgQg2WAy9Yqw6NBtlY5vpqPJjS/2eBMsIg==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3"

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
     "libs/*"
   ],
   "dependencies": {
-    "@blue-labs/language": "2.0.0-rc.20",
-    "@blue-labs/repository-contract": "2.0.0-rc.20",
+    "@blue-labs/language": "^4.0.0",
+    "@blue-labs/repository-contract": "^4.0.0",
     "@nx/devkit": "22.0.2",
     "@phenomnomnominal/tsquery": "6.1.3",
     "zod": "^3.23.8"


### PR DESCRIPTION
## Summary
- update root dependencies to @blue-labs/language@4.0.0 and @blue-labs/repository-contract@4.0.0
- keep this as a project-scoped chore commit so Nx release does not bump @blue-repository/types

## Verification
- npx nx release --first-release --skip-publish --dry-run --verbose
  - Nx reported: No changes were detected using git history and the conventional commits standard
  - no version files, changelog entries, GitHub release, or publish were planned
