### PR TITLE
feat: update BlueRepository.blue + regenerate types (run 25455366356, trigger: repository_dispatch (blue-preprocessor-completed))

### DIFF
--- a/BlueRepository.blue
+++ b/BlueRepository.blue
@@ -2465,6 +2465,41 @@ packages:
             attributesAdded: []
       - status: stable
         content:
+          name: Document Initial Snapshot Requested
+          type:
+            blueId: 8f9UhHMbRe62sFgzQVheToaJPYi7t7HPNVvpQTbqfL5n
+          sourceSessionId:
+            type:
+              blueId: DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K
+        versions:
+          - repositoryVersionIndex: 2
+            typeBlueId: CTFByfge1uHNvbNNWP92XrGng1HnqAKVz9Wq1Tvg5x2T
+            attributesAdded: []
+      - status: stable
+        content:
+          name: Document Initial Snapshot Resolved
+          type:
+            blueId: 36epvrpVHZLjapbeZsNodz2NDnm7XZeNZcnkWHgkP1pp
+          document:
+            description: Initial snapshot of requested document session.
+        versions:
+          - repositoryVersionIndex: 2
+            typeBlueId: GAFsQ4MjLuJZfEgPE1J1jp8fpihkgRq6Q1meF4xsmJYv
+            attributesAdded: []
+      - status: stable
+        content:
+          name: Document Initial Snapshot Unresolved
+          type:
+            blueId: 36epvrpVHZLjapbeZsNodz2NDnm7XZeNZcnkWHgkP1pp
+          reason:
+            type:
+              blueId: DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K
+        versions:
+          - repositoryVersionIndex: 2
+            typeBlueId: u64K6E1Yv7NWsaYuAExGJDaTcffX6Q4iSbUkgxZB1v9
+            attributesAdded: []
+      - status: stable
+        content:
           name: Document Link
           description: Link targeting a specific Blue document by its stable documentId (initial blueId before any processing). Used to point to a logical document regardless of session.
           type:
@@ -9689,3 +9724,4 @@ packages:
 repositoryVersions:
   - 5gmX9Fhnu4qM9ZJuqKAVZQXCQng3h4hZbWoaSEufSzij
   - B4qWEbNWRcgabYrDTxtebfRSP5nBnEYvpX5YWqa2PcE4
+  - sUk1iHFrf7UQXAMeQvWRyvYVxxStUjfARaE5e4EgDKv

--- a/libs/types/README.md
+++ b/libs/types/README.md
@@ -12,7 +12,7 @@ It contains:
 ## Repository Information
 
 - Repository name: **Blue Repository**
-- RepoBlueId: **B4qWEbNWRcgabYrDTxtebfRSP5nBnEYvpX5YWqa2PcE4**
+- RepoBlueId: **sUk1iHFrf7UQXAMeQvWRyvYVxxStUjfARaE5e4EgDKv**
 
 ## Installation
 

--- a/libs/types/package.json
+++ b/libs/types/package.json
@@ -100,6 +100,6 @@
   },
   "blueType": {
     "moduleName": "Blue Repository",
-    "moduleBlueId": "B4qWEbNWRcgabYrDTxtebfRSP5nBnEYvpX5YWqa2PcE4"
+    "moduleBlueId": "sUk1iHFrf7UQXAMeQvWRyvYVxxStUjfARaE5e4EgDKv"
   }
 }

--- a/libs/types/src/meta.ts
+++ b/libs/types/src/meta.ts
@@ -2,5 +2,6 @@ export const name = 'Blue Repository' as const;
 export const repositoryVersions = [
   '5gmX9Fhnu4qM9ZJuqKAVZQXCQng3h4hZbWoaSEufSzij',
   'B4qWEbNWRcgabYrDTxtebfRSP5nBnEYvpX5YWqa2PcE4',
+  'sUk1iHFrf7UQXAMeQvWRyvYVxxStUjfARaE5e4EgDKv',
 ] as const;
 export default { name, repositoryVersions } as const;

--- a/libs/types/src/packages/myos/blue-ids.ts
+++ b/libs/types/src/packages/myos/blue-ids.ts
@@ -20,6 +20,12 @@ export const blueIds = {
     '3u1bvMQqqc9sj4zWmwwhQrbdfCn7xrGiN7KEczqq22XG',
   'MyOS/Document Anchor': 'HS9yo34TGEAM2LGcNbLh7XPN4goPRhqdGZQkiyh473Wb',
   'MyOS/Document Anchors': '7Usvk6dZMVqas3yqs23ZEXn1zu1YDPjgYiZFNYaw3puH',
+  'MyOS/Document Initial Snapshot Requested':
+    'CTFByfge1uHNvbNNWP92XrGng1HnqAKVz9Wq1Tvg5x2T',
+  'MyOS/Document Initial Snapshot Resolved':
+    'GAFsQ4MjLuJZfEgPE1J1jp8fpihkgRq6Q1meF4xsmJYv',
+  'MyOS/Document Initial Snapshot Unresolved':
+    'u64K6E1Yv7NWsaYuAExGJDaTcffX6Q4iSbUkgxZB1v9',
   'MyOS/Document Link': 'BFxgEnovNHQ693YR2YvALi4FP8vjcwSQiX63LiLwjUhk',
   'MyOS/Document Links': '4cmrbevB6K23ZenjqwmNxpnaw6RF4VB3wkP7XB59V7W5',
   'MyOS/Document Session Bootstrap':

--- a/libs/types/src/packages/myos/contents/DocumentInitialSnapshotRequested.ts
+++ b/libs/types/src/packages/myos/contents/DocumentInitialSnapshotRequested.ts
@@ -1,0 +1,11 @@
+export const DocumentInitialSnapshotRequested = {
+  name: 'Document Initial Snapshot Requested',
+  sourceSessionId: {
+    type: {
+      blueId: 'DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K',
+    },
+  },
+  type: {
+    blueId: '8f9UhHMbRe62sFgzQVheToaJPYi7t7HPNVvpQTbqfL5n',
+  },
+} as const;

--- a/libs/types/src/packages/myos/contents/DocumentInitialSnapshotResolved.ts
+++ b/libs/types/src/packages/myos/contents/DocumentInitialSnapshotResolved.ts
@@ -1,0 +1,9 @@
+export const DocumentInitialSnapshotResolved = {
+  document: {
+    description: 'Initial snapshot of requested document session.',
+  },
+  name: 'Document Initial Snapshot Resolved',
+  type: {
+    blueId: '36epvrpVHZLjapbeZsNodz2NDnm7XZeNZcnkWHgkP1pp',
+  },
+} as const;

--- a/libs/types/src/packages/myos/contents/DocumentInitialSnapshotUnresolved.ts
+++ b/libs/types/src/packages/myos/contents/DocumentInitialSnapshotUnresolved.ts
@@ -1,0 +1,11 @@
+export const DocumentInitialSnapshotUnresolved = {
+  name: 'Document Initial Snapshot Unresolved',
+  reason: {
+    type: {
+      blueId: 'DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K',
+    },
+  },
+  type: {
+    blueId: '36epvrpVHZLjapbeZsNodz2NDnm7XZeNZcnkWHgkP1pp',
+  },
+} as const;

--- a/libs/types/src/packages/myos/contents/index.ts
+++ b/libs/types/src/packages/myos/contents/index.ts
@@ -60,6 +60,7 @@ import { ParticipantActivationState } from './ParticipantActivationState';
 import { WorkerAgencyPermissionGrant } from './WorkerAgencyPermissionGrant';
 import { InformUserToInstallMyOSPackage } from './InformUserToInstallMyOSPackage';
 import { SingleDocumentPermissionRevokingInProgress } from './SingleDocumentPermissionRevokingInProgress';
+import { DocumentInitialSnapshotRequested } from './DocumentInitialSnapshotRequested';
 import { MyOSSessionLink } from './MyOSSessionLink';
 import { Link } from './Link';
 import { DocumentTypeLink } from './DocumentTypeLink';
@@ -80,6 +81,7 @@ import { SingleDocumentPermissionGrantRequested } from './SingleDocumentPermissi
 import { AllParticipantsReady } from './AllParticipantsReady';
 import { TargetDocumentSessionStarted } from './TargetDocumentSessionStarted';
 import { LinkedDocumentsPermissionGrantToAccount } from './LinkedDocumentsPermissionGrantToAccount';
+import { DocumentInitialSnapshotResolved } from './DocumentInitialSnapshotResolved';
 import { SubscriptionToSessionRevoked } from './SubscriptionToSessionRevoked';
 import { LinkedDocumentsPermissionRejected } from './LinkedDocumentsPermissionRejected';
 import { PaymentInitiationAccepted } from './PaymentInitiationAccepted';
@@ -96,6 +98,7 @@ import { SingleDocumentPermissionRejected } from './SingleDocumentPermissionReje
 import { PaymentTargetPrepared } from './PaymentTargetPrepared';
 import { Participant } from './Participant';
 import { SubscriptionToSessionFailed } from './SubscriptionToSessionFailed';
+import { DocumentInitialSnapshotUnresolved } from './DocumentInitialSnapshotUnresolved';
 
 export { PaymentInitiationRequested } from './PaymentInitiationRequested';
 export { SingleDocumentPermissionRevoked } from './SingleDocumentPermissionRevoked';
@@ -159,6 +162,7 @@ export { ParticipantActivationState } from './ParticipantActivationState';
 export { WorkerAgencyPermissionGrant } from './WorkerAgencyPermissionGrant';
 export { InformUserToInstallMyOSPackage } from './InformUserToInstallMyOSPackage';
 export { SingleDocumentPermissionRevokingInProgress } from './SingleDocumentPermissionRevokingInProgress';
+export { DocumentInitialSnapshotRequested } from './DocumentInitialSnapshotRequested';
 export { MyOSSessionLink } from './MyOSSessionLink';
 export { Link } from './Link';
 export { DocumentTypeLink } from './DocumentTypeLink';
@@ -179,6 +183,7 @@ export { SingleDocumentPermissionGrantRequested } from './SingleDocumentPermissi
 export { AllParticipantsReady } from './AllParticipantsReady';
 export { TargetDocumentSessionStarted } from './TargetDocumentSessionStarted';
 export { LinkedDocumentsPermissionGrantToAccount } from './LinkedDocumentsPermissionGrantToAccount';
+export { DocumentInitialSnapshotResolved } from './DocumentInitialSnapshotResolved';
 export { SubscriptionToSessionRevoked } from './SubscriptionToSessionRevoked';
 export { LinkedDocumentsPermissionRejected } from './LinkedDocumentsPermissionRejected';
 export { PaymentInitiationAccepted } from './PaymentInitiationAccepted';
@@ -195,6 +200,7 @@ export { SingleDocumentPermissionRejected } from './SingleDocumentPermissionReje
 export { PaymentTargetPrepared } from './PaymentTargetPrepared';
 export { Participant } from './Participant';
 export { SubscriptionToSessionFailed } from './SubscriptionToSessionFailed';
+export { DocumentInitialSnapshotUnresolved } from './DocumentInitialSnapshotUnresolved';
 
 export const contents = {
   '26eFVecG5eovbFVYf7YcdN2bFhuFiNhRFxrCZSBb1H3r': PaymentInitiationRequested,
@@ -277,6 +283,8 @@ export const contents = {
   CrGV4ZYjvPvMqrgNQAfgZCUnFjFW6HDjYNdon2chLKU3: InformUserToInstallMyOSPackage,
   CrRfT3MFQneNo99nfdhfgnTKF4fmKtSQEUQN8wTTbnjF:
     SingleDocumentPermissionRevokingInProgress,
+  CTFByfge1uHNvbNNWP92XrGng1HnqAKVz9Wq1Tvg5x2T:
+    DocumentInitialSnapshotRequested,
   d1vQ8ZTPcQc5KeuU6tzWaVukWRVtKjQL4hbvbpC22rB: MyOSSessionLink,
   D2ERUvbpn6R6PR7hjFsGofwQsu9bkRfc6wbSYHcfJtMD: Link,
   D9Ret9Hmz5TWxzuJEeauWEuZVPkPL7hcHYsSNY1cZ5zX: DocumentTypeLink,
@@ -302,6 +310,7 @@ export const contents = {
   FoHDf4WzS4idtPc8rWwVFFvALQ27WzMHxPdXovy7DH4p: TargetDocumentSessionStarted,
   FuQov123cM3ph1xcX5Cyx19D2w1vsitpAHfkdasZDE75:
     LinkedDocumentsPermissionGrantToAccount,
+  GAFsQ4MjLuJZfEgPE1J1jp8fpihkgRq6Q1meF4xsmJYv: DocumentInitialSnapshotResolved,
   GcotFgiqo3GMHp4xKrArDJi7AqciJGgYKvHodoAJwcWp: SubscriptionToSessionRevoked,
   GFs1qrcTSzYq5tEN25GjGngu7fttnPgma6PU7TQ89Hjc:
     LinkedDocumentsPermissionRejected,
@@ -322,4 +331,6 @@ export const contents = {
   N7tRCfv2oxjN8ncrkPQb8c16CjUdJbM7aWDUJDR1C5k: PaymentTargetPrepared,
   phD9k4YTUgGjWeLPKqXNNn6S1PmqSeBJfVscAnUwFhQ: Participant,
   S1gzGs6z9uy5inkcJu5wr6i5ESKDmZy9XhgLHMZKrdV: SubscriptionToSessionFailed,
+  u64K6E1Yv7NWsaYuAExGJDaTcffX6Q4iSbUkgxZB1v9:
+    DocumentInitialSnapshotUnresolved,
 } as const;

--- a/libs/types/src/packages/myos/meta.ts
+++ b/libs/types/src/packages/myos/meta.ts
@@ -157,6 +157,39 @@ const meta = {
         },
       ],
     },
+    CTFByfge1uHNvbNNWP92XrGng1HnqAKVz9Wq1Tvg5x2T: {
+      status: 'stable',
+      name: 'Document Initial Snapshot Requested',
+      versions: [
+        {
+          repositoryVersionIndex: 2,
+          typeBlueId: 'CTFByfge1uHNvbNNWP92XrGng1HnqAKVz9Wq1Tvg5x2T',
+          attributesAdded: [],
+        },
+      ],
+    },
+    GAFsQ4MjLuJZfEgPE1J1jp8fpihkgRq6Q1meF4xsmJYv: {
+      status: 'stable',
+      name: 'Document Initial Snapshot Resolved',
+      versions: [
+        {
+          repositoryVersionIndex: 2,
+          typeBlueId: 'GAFsQ4MjLuJZfEgPE1J1jp8fpihkgRq6Q1meF4xsmJYv',
+          attributesAdded: [],
+        },
+      ],
+    },
+    u64K6E1Yv7NWsaYuAExGJDaTcffX6Q4iSbUkgxZB1v9: {
+      status: 'stable',
+      name: 'Document Initial Snapshot Unresolved',
+      versions: [
+        {
+          repositoryVersionIndex: 2,
+          typeBlueId: 'u64K6E1Yv7NWsaYuAExGJDaTcffX6Q4iSbUkgxZB1v9',
+          attributesAdded: [],
+        },
+      ],
+    },
     BFxgEnovNHQ693YR2YvALi4FP8vjcwSQiX63LiLwjUhk: {
       status: 'stable',
       name: 'Document Link',

--- a/libs/types/src/packages/myos/schemas/DocumentInitialSnapshotRequested.ts
+++ b/libs/types/src/packages/myos/schemas/DocumentInitialSnapshotRequested.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+import { blueIds } from '../blue-ids';
+import { withTypeBlueId } from '@blue-labs/language';
+import { RequestSchema } from '../../conversation/schemas/Request';
+
+export const DocumentInitialSnapshotRequestedSchema = withTypeBlueId(
+  blueIds['MyOS/Document Initial Snapshot Requested']
+)(
+  RequestSchema.extend({
+    name: z.string().optional(),
+    sourceSessionId: z.string().optional(),
+  })
+);
+
+export type DocumentInitialSnapshotRequested = z.infer<
+  typeof DocumentInitialSnapshotRequestedSchema
+>;

--- a/libs/types/src/packages/myos/schemas/DocumentInitialSnapshotResolved.ts
+++ b/libs/types/src/packages/myos/schemas/DocumentInitialSnapshotResolved.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+import { blueIds } from '../blue-ids';
+import { withTypeBlueId, blueNodeField } from '@blue-labs/language';
+import { ResponseSchema } from '../../conversation/schemas/Response';
+
+export const DocumentInitialSnapshotResolvedSchema = withTypeBlueId(
+  blueIds['MyOS/Document Initial Snapshot Resolved']
+)(
+  ResponseSchema.extend({
+    document: blueNodeField().optional(),
+    name: z.string().optional(),
+  })
+);
+
+export type DocumentInitialSnapshotResolved = z.infer<
+  typeof DocumentInitialSnapshotResolvedSchema
+>;

--- a/libs/types/src/packages/myos/schemas/DocumentInitialSnapshotUnresolved.ts
+++ b/libs/types/src/packages/myos/schemas/DocumentInitialSnapshotUnresolved.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+import { blueIds } from '../blue-ids';
+import { withTypeBlueId } from '@blue-labs/language';
+import { ResponseSchema } from '../../conversation/schemas/Response';
+
+export const DocumentInitialSnapshotUnresolvedSchema = withTypeBlueId(
+  blueIds['MyOS/Document Initial Snapshot Unresolved']
+)(
+  ResponseSchema.extend({
+    name: z.string().optional(),
+    reason: z.string().optional(),
+  })
+);
+
+export type DocumentInitialSnapshotUnresolved = z.infer<
+  typeof DocumentInitialSnapshotUnresolvedSchema
+>;

--- a/libs/types/src/packages/myos/schemas/index.ts
+++ b/libs/types/src/packages/myos/schemas/index.ts
@@ -12,6 +12,9 @@ import { CallOperationRespondedSchema } from './CallOperationResponded';
 import { ChatGPTConnectorAgentSchema } from './ChatGPTConnectorAgent';
 import { DocumentAnchorSchema } from './DocumentAnchor';
 import { DocumentAnchorsSchema } from './DocumentAnchors';
+import { DocumentInitialSnapshotRequestedSchema } from './DocumentInitialSnapshotRequested';
+import { DocumentInitialSnapshotResolvedSchema } from './DocumentInitialSnapshotResolved';
+import { DocumentInitialSnapshotUnresolvedSchema } from './DocumentInitialSnapshotUnresolved';
 import { DocumentLinkSchema } from './DocumentLink';
 import { DocumentLinksSchema } from './DocumentLinks';
 import { DocumentSessionBootstrapSchema } from './DocumentSessionBootstrap';
@@ -111,6 +114,9 @@ export { CallOperationRespondedSchema } from './CallOperationResponded';
 export { ChatGPTConnectorAgentSchema } from './ChatGPTConnectorAgent';
 export { DocumentAnchorSchema } from './DocumentAnchor';
 export { DocumentAnchorsSchema } from './DocumentAnchors';
+export { DocumentInitialSnapshotRequestedSchema } from './DocumentInitialSnapshotRequested';
+export { DocumentInitialSnapshotResolvedSchema } from './DocumentInitialSnapshotResolved';
+export { DocumentInitialSnapshotUnresolvedSchema } from './DocumentInitialSnapshotUnresolved';
 export { DocumentLinkSchema } from './DocumentLink';
 export { DocumentLinksSchema } from './DocumentLinks';
 export { DocumentSessionBootstrapSchema } from './DocumentSessionBootstrap';
@@ -214,6 +220,12 @@ export const schemas = {
   '3u1bvMQqqc9sj4zWmwwhQrbdfCn7xrGiN7KEczqq22XG': ChatGPTConnectorAgentSchema,
   HS9yo34TGEAM2LGcNbLh7XPN4goPRhqdGZQkiyh473Wb: DocumentAnchorSchema,
   '7Usvk6dZMVqas3yqs23ZEXn1zu1YDPjgYiZFNYaw3puH': DocumentAnchorsSchema,
+  CTFByfge1uHNvbNNWP92XrGng1HnqAKVz9Wq1Tvg5x2T:
+    DocumentInitialSnapshotRequestedSchema,
+  GAFsQ4MjLuJZfEgPE1J1jp8fpihkgRq6Q1meF4xsmJYv:
+    DocumentInitialSnapshotResolvedSchema,
+  u64K6E1Yv7NWsaYuAExGJDaTcffX6Q4iSbUkgxZB1v9:
+    DocumentInitialSnapshotUnresolvedSchema,
   BFxgEnovNHQ693YR2YvALi4FP8vjcwSQiX63LiLwjUhk: DocumentLinkSchema,
   '4cmrbevB6K23ZenjqwmNxpnaw6RF4VB3wkP7XB59V7W5': DocumentLinksSchema,
   AhSRfEjNdQ8AvA3AFigjdyQzAtoc2J29jpacEcKBNa32: DocumentSessionBootstrapSchema,


### PR DESCRIPTION
This PR contains an updated repository definition (BlueRepository.blue) and regenerated @blue-repository/types sources.

## Configuration
- Trigger: repository_dispatch (blue-preprocessor-completed)
- Run ID: 25455366356
- Source workflow: blue-preprocessor.yml
- Artifact: blue-repository-definition

## Changes
- Updated BlueRepository.blue
- Regenerated libs/types/src (contents, schemas, blue-ids, package exports)

Generated by the process-blue-artifacts workflow.